### PR TITLE
Feat(#12): BaseEntity, Status클래스 구현

### DIFF
--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/global/entity/BaseEntity.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/global/entity/BaseEntity.java
@@ -1,0 +1,31 @@
+package shop.kkeujeok.kkeujeokbackend.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/global/entity/Status.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/global/entity/Status.java
@@ -1,0 +1,6 @@
+package shop.kkeujeok.kkeujeokbackend.global.entity;
+
+public enum Status {
+    // A : 활성화, D : 비활성화
+    A, D
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #12 

## 📝작업 내용

- 속성이 Id, 생성 시간, 수정 시간인 BaseEntity 클래스 구현
- 엔티티의 상태를 알려주는 Status 클래스 구현

## 💬리뷰 요구사항

> BaseEntity에 Id를 넣어 엔티티에서 Id를 관리하지 않고 해당 클래스를 상속하는 방식은 어떨까요?
저희 서비스 특성상 erd를 봤을 때 모두 BaseEntity 상속이 필요한 테이블이더라고요.
이와 같이 설정하면 중복 되는 값을 좀 덜어줄 수 있을 것 같아요.
