### PR TITLE
Feat(#11, #18): 블록 엔티티, 저장 기능, 저장 테스트 코드 구현

### DIFF
--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockController.java
@@ -1,0 +1,24 @@
+package shop.kkeujeok.kkeujeokbackend.block.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shop.kkeujeok.kkeujeokbackend.block.api.dto.request.BlockSaveReqDto;
+import shop.kkeujeok.kkeujeokbackend.block.api.dto.response.BlockInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.block.application.BlockService;
+import shop.kkeujeok.kkeujeokbackend.global.template.RspTemplate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/blocks")
+public class BlockController {
+    private final BlockService blockService;
+
+    @PostMapping("/")
+    public RspTemplate<BlockInfoResDto> save(@RequestBody BlockSaveReqDto blockSaveReqDto) {
+        return new RspTemplate<>(HttpStatus.CREATED, "블럭 생성", blockService.save(blockSaveReqDto));
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/dto/request/BlockSaveReqDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/dto/request/BlockSaveReqDto.java
@@ -1,0 +1,20 @@
+package shop.kkeujeok.kkeujeokbackend.block.api.dto.request;
+
+import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+public record BlockSaveReqDto(
+        String title,
+        String contents,
+        Progress progress
+) {
+    public Block toEntity(Member member) {
+        return Block.builder()
+                .title(title)
+                .contents(contents)
+                .progress(progress)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/dto/response/BlockInfoResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/dto/response/BlockInfoResDto.java
@@ -1,0 +1,23 @@
+package shop.kkeujeok.kkeujeokbackend.block.api.dto.response;
+
+import lombok.Builder;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+@Builder
+public record BlockInfoResDto(
+        String title,
+        String contents,
+        Progress progress,
+        String nickname
+) {
+    public static BlockInfoResDto of(Block block, Member member) {
+        return BlockInfoResDto.builder()
+                .title(block.getTitle())
+                .contents(block.getContents())
+                .progress(block.getProgress())
+                .nickname(member.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
@@ -1,0 +1,36 @@
+package shop.kkeujeok.kkeujeokbackend.block.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.kkeujeok.kkeujeokbackend.block.api.dto.request.BlockSaveReqDto;
+import shop.kkeujeok.kkeujeokbackend.block.api.dto.response.BlockInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
+import shop.kkeujeok.kkeujeokbackend.block.domain.repository.BlockRepository;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BlockService {
+    private final BlockRepository blockRepository;
+
+    // 블록 생성
+    @Transactional
+    public BlockInfoResDto save(BlockSaveReqDto blockSaveReqDto) {
+        // 로그인/회원가입 코드 완성 후 사용자 정보 받아올 예정
+        Member member = Member.builder().nickname("member").build();
+        Block block = blockRepository.save(blockSaveReqDto.toEntity(member));
+
+        return BlockInfoResDto.of(block, member);
+    }
+
+    // 블록 수정 (자동 수정 예정)
+
+    // 블록 삭제 (논리 삭제)
+
+    // 블록 리스트
+
+    // 블록 상세보기
+
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/Block.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/Block.java
@@ -1,32 +1,46 @@
 package shop.kkeujeok.kkeujeokbackend.block.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import shop.kkeujeok.kkeujeokbackend.global.entity.BaseEntity;
 import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Block extends BaseEntity {
 
+    @Enumerated(value = EnumType.STRING)
     private Status status;
 
     private String title;
 
+    @Column(columnDefinition = "TEXT")
     private String contents;
 
+    @Enumerated(value = EnumType.STRING)
     private Progress progress;
 
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
     @Builder
-    private Block(String title, String contents, Progress progress) {
+    private Block(String title, String contents, Progress progress, Member member) {
         this.status = Status.A;
         this.title = title;
         this.contents = contents;
         this.progress = progress;
+        this.member = member;
     }
 
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/Block.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/Block.java
@@ -1,0 +1,32 @@
+package shop.kkeujeok.kkeujeokbackend.block.domain;
+
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import shop.kkeujeok.kkeujeokbackend.global.entity.BaseEntity;
+import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Block extends BaseEntity {
+
+    private Status status;
+
+    private String title;
+
+    private String contents;
+
+    private Progress progress;
+
+    @Builder
+    private Block(String title, String contents, Progress progress) {
+        this.status = Status.A;
+        this.title = title;
+        this.contents = contents;
+        this.progress = progress;
+    }
+
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/Progress.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/Progress.java
@@ -1,0 +1,17 @@
+package shop.kkeujeok.kkeujeokbackend.block.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum Progress {
+    NOT_STARTED("시작 전"),
+    IN_PROGRESS("진행 중"),
+    COMPLETED("완료");
+
+    private final String description;
+
+    Progress(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockRepository.java
@@ -1,0 +1,7 @@
+package shop.kkeujeok.kkeujeokbackend.block.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
+
+public interface BlockRepository extends JpaRepository<Block, Long> {
+}

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockControllerTest.java
@@ -1,0 +1,74 @@
+package shop.kkeujeok.kkeujeokbackend.block.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import shop.kkeujeok.kkeujeokbackend.block.api.dto.request.BlockSaveReqDto;
+import shop.kkeujeok.kkeujeokbackend.block.api.dto.response.BlockInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.block.application.BlockService;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+@WebMvcTest(BlockController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+class BlockControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private BlockService blockService;
+
+    private Member member;
+    private Block block;
+    private BlockSaveReqDto blockSaveReqDto;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .nickname("웅이")
+                .build();
+        blockSaveReqDto = new BlockSaveReqDto("Title", "Contents", Progress.NOT_STARTED);
+        block = blockSaveReqDto.toEntity(member);
+    }
+
+    @DisplayName("POST 블록 저장 컨트롤러 로직 확인")
+    @Test
+    void 블록_저장() throws Exception {
+        // given
+        BlockInfoResDto response = BlockInfoResDto.of(block, member);
+        given(blockService.save(any(BlockSaveReqDto.class))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/blocks/")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(blockSaveReqDto))
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(201))
+                .andExpect(jsonPath("$.message").value("블럭 생성"))
+                .andExpect(jsonPath("$.data.title").value("Title"))
+                .andExpect(jsonPath("$.data.contents").value("Contents"))
+                .andExpect(jsonPath("$.data.progress").value("NOT_STARTED"))
+                .andExpect(jsonPath("$.data.nickname").value("웅이"));
+    }
+
+}

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockServiceTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockServiceTest.java
@@ -1,0 +1,63 @@
+package shop.kkeujeok.kkeujeokbackend.block.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import shop.kkeujeok.kkeujeokbackend.block.api.dto.request.BlockSaveReqDto;
+import shop.kkeujeok.kkeujeokbackend.block.api.dto.response.BlockInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
+import shop.kkeujeok.kkeujeokbackend.block.domain.repository.BlockRepository;
+
+@ExtendWith(MockitoExtension.class)
+class BlockServiceTest {
+
+    @Mock
+    private BlockRepository blockRepository;
+
+    @InjectMocks
+    private BlockService blockService;
+
+    private Block block;
+    private BlockSaveReqDto blockSaveReqDto;
+
+    @BeforeEach
+    void setUp() {
+        blockSaveReqDto = new BlockSaveReqDto("Title", "Contents", Progress.NOT_STARTED);
+        block = Block.builder()
+                .title(blockSaveReqDto.title())
+                .contents(blockSaveReqDto.contents())
+                .progress(blockSaveReqDto.progress())
+                .build();
+    }
+
+    @DisplayName("블록을 저장합니다.")
+    @Test
+    void 블록_저장() {
+        // given
+        when(blockRepository.save(any(Block.class))).thenReturn(block);
+
+        // when
+        BlockInfoResDto result = blockService.save(blockSaveReqDto);
+
+        // then
+        assertAll(() -> {
+            assertThat(result.title()).isEqualTo("Title");
+            assertThat(result.contents()).isEqualTo("Contents");
+            assertThat(result.progress()).isEqualTo(Progress.NOT_STARTED);
+            assertNotNull(result.nickname());
+        });
+
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #11, #18 

## 📝작업 내용

> Block 엔티티 구현
> Block 저장 기능 구현
> Block 저장 테스트 코드 구현

추후 로그인/회원가입 코드가 완성되면 BlockService의 Member를 호출하는 코드가 변경될 것 입니다.
그리고 테스트코드의 setUp 메서드나 공통으로 사용되는 필드는 클래스(상속), 정적 메소드 또는 정적 변수로 변경할 예정입니다.