### PR TITLE
Feat(#11 #18): Block 논리 삭제 기능 구현, Block 상태별 전체조회 Query 수정, Block, BlockRepository 테스트 코드 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'com.github.maricn:logback-slack-appender:1.4.0'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
 
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/docs/asciidoc/block.adoc
+++ b/src/docs/asciidoc/block.adoc
@@ -73,3 +73,14 @@ include::{snippets}/block/findById/path-parameters.adoc[]
 
 include::{snippets}/block/findById/http-response.adoc[]
 include::{snippets}/block/findById/response-fields.adoc[]
+
+=== 블록 삭제
+
+==== 요청
+
+include::{snippets}/block/delete/http-request.adoc[]
+include::{snippets}/block/delete/path-parameters.adoc[]
+
+==== 응답
+
+include::{snippets}/block/delete/http-response.adoc[]

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockController.java
@@ -3,6 +3,7 @@ package shop.kkeujeok.kkeujeokbackend.block.api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -48,6 +49,12 @@ public class BlockController {
         return new RspTemplate<>(HttpStatus.OK,
                 "블록 상태별 전체 조회",
                 blockService.findByBlockWithProgress(progress, PageRequest.of(page, size)));
+    }
+
+    @DeleteMapping("/{blockId}")
+    public RspTemplate<Void> delete(@PathVariable(name = "blockId") Long blockId) {
+        blockService.delete(blockId);
+        return new RspTemplate<>(HttpStatus.OK, "블록 삭제");
     }
 
     @GetMapping("/{blockId}")

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
@@ -86,8 +86,15 @@ public class BlockService {
         return BlockInfoResDto.of(block, member);
     }
 
-    // 블록 삭제 (논리 삭제)
+    // 블록 삭제 유무 업데이트 (논리 삭제)
+    @Transactional
+    public void delete(Long blockId) {
+        // 로그인/회원가입 코드 완성 후 사용자 정보 받아올 예정
+        Member member = Member.builder().nickname("member").build();
+        Block block = blockRepository.findById(blockId).orElseThrow(BlockNotFoundException::new);
 
+        block.statusUpdate();
+    }
 
     private Progress parseProgress(String progressString) {
         try {

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/Block.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/Block.java
@@ -64,4 +64,8 @@ public class Block extends BaseEntity {
         this.progress = progress;
     }
 
+    public void statusUpdate() {
+        this.status = (this.status == Status.A) ? Status.D : Status.A;
+    }
+
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockCustomRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
+import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
 
 @Repository
 @Transactional(readOnly = true)
@@ -31,7 +32,8 @@ public class BlockCustomRepositoryImpl implements BlockCustomRepository {
 
         List<Block> blocks = queryFactory
                 .selectFrom(block)
-                .where(block.progress.eq(progress))
+                .where(block.progress.eq(progress)
+                        .and(block.status.eq(Status.A)))
                 .orderBy(block.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockControllerTest.java
@@ -4,7 +4,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -194,6 +196,27 @@ class BlockControllerTest extends ControllerTest {
                         )
                 ))
                 .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("Delete 블록을 논리적으로 삭제합니다.")
+    @Test
+    void 블록_삭제() throws Exception {
+        // given
+        Long blockId = 1L;
+        doNothing().when(blockService).delete(anyLong());
+
+        // when & then
+        mockMvc.perform(delete("/api/blocks/{blockId}", blockId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("block/delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("blockId").description("블록 ID")
+                        )
+                ))
+                .andExpect(status().isOk());
     }
 
     @DisplayName("GET 블록을 상태별로 전체 조회합니다.")

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockServiceTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockServiceTest.java
@@ -22,6 +22,7 @@ import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
 import shop.kkeujeok.kkeujeokbackend.block.domain.repository.BlockRepository;
 import shop.kkeujeok.kkeujeokbackend.block.exception.InvalidProgressException;
+import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
 
 @ExtendWith(MockitoExtension.class)
 class BlockServiceTest {
@@ -33,6 +34,7 @@ class BlockServiceTest {
     private BlockService blockService;
 
     private Block block;
+    private Block deleteBlock;
     private BlockSaveReqDto blockSaveReqDto;
     private BlockUpdateReqDto blockUpdateReqDto;
 
@@ -46,6 +48,14 @@ class BlockServiceTest {
                 .progress(blockSaveReqDto.progress())
                 .deadLine(blockSaveReqDto.deadLine())
                 .build();
+
+        deleteBlock = Block.builder()
+                .title(blockSaveReqDto.title())
+                .contents(blockSaveReqDto.contents())
+                .progress(blockSaveReqDto.progress())
+                .deadLine(blockSaveReqDto.deadLine())
+                .build();
+        deleteBlock.statusUpdate();
     }
 
     @DisplayName("블록을 저장합니다.")
@@ -133,6 +143,38 @@ class BlockServiceTest {
         // when & then
         assertThatThrownBy(() -> blockService.progressUpdate(blockId, "String"))
                 .isInstanceOf(InvalidProgressException.class);
+    }
+
+    @DisplayName("블록을 삭제 합니다.")
+    @Test
+    void 블록_삭제() {
+        // given
+        Long blockId = 1L;
+        when(blockRepository.findById(blockId)).thenReturn(Optional.of(block));
+
+        // when
+        blockService.delete(blockId);
+
+        // then
+        assertAll(() -> {
+            assertThat(block.getStatus()).isEqualTo(Status.D);
+        });
+    }
+
+    @DisplayName("삭제되었던 블록을 복구합니다.")
+    @Test
+    void 블록_복구() {
+        // given
+        Long blockId = 1L;
+        when(blockRepository.findById(blockId)).thenReturn(Optional.of(deleteBlock));
+
+        // when
+        blockService.delete(blockId);
+
+        // then
+        assertAll(() -> {
+            assertThat(deleteBlock.getStatus()).isEqualTo(Status.A);
+        });
     }
 
     @DisplayName("블록을 상세 봅니다.")

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/block/domain/BlockTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/block/domain/BlockTest.java
@@ -1,0 +1,134 @@
+package shop.kkeujeok.kkeujeokbackend.block.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
+
+class BlockTest {
+    private String title;
+    private String contents;
+    private String deadLine;
+
+    private Block block;
+
+    @BeforeEach
+    void setUp() {
+        title = "title";
+        contents = "contents";
+        deadLine = "2024.07.27 22:34";
+
+        block = Block.builder()
+                .title(title)
+                .contents(contents)
+                .progress(Progress.NOT_STARTED)
+                .deadLine(deadLine)
+                .build();
+    }
+
+    @DisplayName("블록의 모든 값을 수정합니다.")
+    @Test
+    void 블록_수정() {
+        // given
+        String updateTitle = "updateTitle";
+        String updateContents = "updateContents";
+        String updateDeadLine = "updateDeadLine";
+
+        // when
+        block.update(updateTitle, updateContents, updateDeadLine);
+
+        // then
+        assertAll(() -> {
+            assertThat(block.getTitle()).isEqualTo(updateTitle);
+            assertThat(block.getContents()).isEqualTo(updateContents);
+            assertThat(block.getDeadLine()).isEqualTo(updateDeadLine);
+        });
+    }
+
+    @DisplayName("블록의 제목만 수정합니다.")
+    @Test
+    void 블록_제목_수정() {
+        // given
+        String updateTitle = "updateTitle";
+
+        // when
+        block.update(updateTitle, contents, deadLine);
+
+        // then
+        assertAll(() -> {
+            assertThat(block.getTitle()).isEqualTo(updateTitle);
+            assertThat(block.getContents()).isEqualTo(contents);
+            assertThat(block.getDeadLine()).isEqualTo(deadLine);
+        });
+    }
+
+    @DisplayName("블록의 내용만 수정합니다.")
+    @Test
+    void 블록_내용_수정() {
+        // given
+        String updateContents = "updateContents";
+
+        // when
+        block.update(title, updateContents, deadLine);
+
+        // then
+        assertAll(() -> {
+            assertThat(block.getTitle()).isEqualTo(title);
+            assertThat(block.getContents()).isEqualTo(updateContents);
+            assertThat(block.getDeadLine()).isEqualTo(deadLine);
+        });
+    }
+
+    @DisplayName("블록의 마감 기한만 수정합니다.")
+    @Test
+    void 블록_마감_기한_수정() {
+        // given
+        String updateDeadLine = "2024.07.28 22:34";
+
+        // when
+        block.update(title, contents, updateDeadLine);
+
+        // then
+        assertAll(() -> {
+            assertThat(block.getTitle()).isEqualTo(title);
+            assertThat(block.getContents()).isEqualTo(contents);
+            assertThat(block.getDeadLine()).isEqualTo(updateDeadLine);
+        });
+    }
+
+    @DisplayName("블록의 진행 상태를 수정합니다.")
+    @Test
+    void 블록_진행_상태_수정() {
+        // given
+        Progress progress = Progress.IN_PROGRESS;
+
+        // when
+        block.progressUpdate(progress);
+
+        // then
+        assertThat(block.getProgress()).isEqualTo(progress);
+    }
+
+    @DisplayName("블록의 논리 삭제 상태를 수정합니다.")
+    @Test
+    void 블록_논리_삭제_수정() {
+        // given
+        assertThat(block.getStatus()).isEqualTo(Status.A);
+
+        // when
+        block.statusUpdate();
+
+        // then
+        assertThat(block.getStatus()).isEqualTo(Status.D);
+
+        // when
+        block.statusUpdate();
+
+        // then
+        assertThat(block.getStatus()).isEqualTo(Status.A);
+    }
+
+}

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockRepositoryTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockRepositoryTest.java
@@ -1,0 +1,107 @@
+package shop.kkeujeok.kkeujeokbackend.block.domain.repository;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
+import shop.kkeujeok.kkeujeokbackend.global.config.JpaAuditingConfig;
+import shop.kkeujeok.kkeujeokbackend.global.config.QuerydslConfig;
+
+@DataJpaTest
+@Import({JpaAuditingConfig.class, QuerydslConfig.class})
+@ActiveProfiles("test")
+class BlockRepositoryTest {
+
+    @Autowired
+    private BlockRepository blockRepository;
+
+    @DisplayName("블록을 진행 상태별로 전체 조회합니다.")
+    @Test
+    void 블록_진행_상태_전체_조회() {
+        // given
+        Block block1 = Block.builder()
+                .title("title1")
+                .contents("contents1")
+                .progress(Progress.NOT_STARTED)
+                .deadLine("2024.07.27 11:03")
+                .build();
+
+        Block block2 = Block.builder()
+                .title("title2")
+                .contents("contents2")
+                .progress(Progress.NOT_STARTED)
+                .deadLine("2024.07.27 11:04")
+                .build();
+
+        Block block3 = Block.builder()
+                .title("title3")
+                .contents("contents3")
+                .progress(Progress.IN_PROGRESS)
+                .deadLine("2024.07.27 11:05")
+                .build();
+
+        blockRepository.save(block1);
+        blockRepository.save(block2);
+        blockRepository.save(block3);
+
+        Progress progress = Progress.NOT_STARTED;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Block> blocks = blockRepository.findByBlockWithProgress(progress, pageable);
+
+        // then
+        assertThat(blocks.getContent().size()).isEqualTo(2);
+    }
+
+    @DisplayName("블록을 논리 삭제 상태별로 전체 조회합니다.")
+    @Test
+    void 블록_삭제_상태_전체_조회() {
+        // given
+        Block block1 = Block.builder()
+                .title("title1")
+                .contents("contents1")
+                .progress(Progress.NOT_STARTED)
+                .deadLine("2024.07.27 11:03")
+                .build();
+
+        Block block2 = Block.builder()
+                .title("title2")
+                .contents("contents2")
+                .progress(Progress.NOT_STARTED)
+                .deadLine("2024.07.27 11:04")
+                .build();
+
+        Block block3 = Block.builder()
+                .title("title3")
+                .contents("contents3")
+                .progress(Progress.IN_PROGRESS)
+                .deadLine("2024.07.27 11:05")
+                .build();
+
+        blockRepository.save(block1);
+        blockRepository.save(block2);
+        blockRepository.save(block3);
+
+        Progress progress = Progress.NOT_STARTED;
+        Pageable pageable = PageRequest.of(0, 10);
+        block1.statusUpdate();
+
+        // when
+        Page<Block> blocks = blockRepository.findByBlockWithProgress(progress, pageable);
+
+        // then
+        assertThat(blocks.getContent().size()).isEqualTo(1);
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #11 #18 

## 📝작업 내용

> 블록 논리 삭제 구현했습니다.
Status.A -> 삭제되지 않은 상태
Status.D -> 삭제된 상태
이에 따라 블록 리스트를 불러오는 로직에서 삭제되지 않은 블록만을 불러옵니다.

> BlockTest, BlockRepositoryTest 코드를 구현하였습니다.
Repository 테스트 코드를 구현하기 위해 h2 데이터베이스 의존성을 추가하였습니다.
h2는 내장형 데이터베이스로써 인메모리 모드로 테스트에 사용됩니다.
데이터는 임시로 유지되고, 데이터베이스를 종료하면 데이터가 사라집니다.