### PR TITLE
Refactor(#11 #18): Block 사용자 선언, dto 정적 팩토리 메소드 수정, ControllerTest Header 추가, mockMvc 설정

### DIFF
--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockController.java
@@ -17,49 +17,58 @@ import shop.kkeujeok.kkeujeokbackend.block.api.dto.request.BlockUpdateReqDto;
 import shop.kkeujeok.kkeujeokbackend.block.api.dto.response.BlockInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.block.api.dto.response.BlockListResDto;
 import shop.kkeujeok.kkeujeokbackend.block.application.BlockService;
+import shop.kkeujeok.kkeujeokbackend.global.annotation.CurrentUserEmail;
 import shop.kkeujeok.kkeujeokbackend.global.template.RspTemplate;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/blocks")
 public class BlockController {
+
     private final BlockService blockService;
 
     @PostMapping("/")
-    public RspTemplate<BlockInfoResDto> save(@RequestBody BlockSaveReqDto blockSaveReqDto) {
-        return new RspTemplate<>(HttpStatus.CREATED, "블럭 생성", blockService.save(blockSaveReqDto));
+    public RspTemplate<BlockInfoResDto> save(
+            @CurrentUserEmail String email,
+            @RequestBody BlockSaveReqDto blockSaveReqDto) {
+        return new RspTemplate<>(HttpStatus.CREATED, "블럭 생성", blockService.save(email, blockSaveReqDto));
     }
 
     @PatchMapping("/{blockId}")
-    public RspTemplate<BlockInfoResDto> update(@PathVariable(name = "blockId") Long blockId,
+    public RspTemplate<BlockInfoResDto> update(@CurrentUserEmail String email,
+                                               @PathVariable(name = "blockId") Long blockId,
                                                @RequestBody BlockUpdateReqDto blockUpdateReqDto) {
-        return new RspTemplate<>(HttpStatus.OK, "블록 수정", blockService.update(blockId, blockUpdateReqDto));
+        return new RspTemplate<>(HttpStatus.OK, "블록 수정", blockService.update(email, blockId, blockUpdateReqDto));
     }
 
     @PatchMapping("/{blockId}/progress")
-    public RspTemplate<BlockInfoResDto> progressUpdate(@PathVariable(name = "blockId") Long blockId,
+    public RspTemplate<BlockInfoResDto> progressUpdate(@CurrentUserEmail String email,
+                                                       @PathVariable(name = "blockId") Long blockId,
                                                        @RequestParam(name = "progress") String progress) {
-        return new RspTemplate<>(HttpStatus.OK, "블록 상태 수정", blockService.progressUpdate(blockId, progress));
+        return new RspTemplate<>(HttpStatus.OK, "블록 상태 수정", blockService.progressUpdate(email, blockId, progress));
     }
 
     @GetMapping("")
-    public RspTemplate<BlockListResDto> findByBlockWithProgress(@RequestParam(name = "progress") String progress,
-                                                                @RequestParam(name = "page", defaultValue = "0") int page,
-                                                                @RequestParam(name = "size", defaultValue = "10") int size) {
+    public RspTemplate<BlockListResDto> findForBlockByProgress(@CurrentUserEmail String email,
+                                                               @RequestParam(name = "progress") String progress,
+                                                               @RequestParam(name = "page", defaultValue = "0") int page,
+                                                               @RequestParam(name = "size", defaultValue = "10") int size) {
         return new RspTemplate<>(HttpStatus.OK,
                 "블록 상태별 전체 조회",
-                blockService.findByBlockWithProgress(progress, PageRequest.of(page, size)));
+                blockService.findForBlockByProgress(email, progress, PageRequest.of(page, size)));
     }
 
     @DeleteMapping("/{blockId}")
-    public RspTemplate<Void> delete(@PathVariable(name = "blockId") Long blockId) {
-        blockService.delete(blockId);
+    public RspTemplate<Void> delete(@CurrentUserEmail String email,
+                                    @PathVariable(name = "blockId") Long blockId) {
+        blockService.delete(email, blockId);
         return new RspTemplate<>(HttpStatus.OK, "블록 삭제");
     }
 
     @GetMapping("/{blockId}")
-    public RspTemplate<BlockInfoResDto> findById(@PathVariable(name = "blockId") Long blockId) {
-        return new RspTemplate<>(HttpStatus.OK, "블록 상세보기", blockService.findById(blockId));
+    public RspTemplate<BlockInfoResDto> findById(@CurrentUserEmail String email,
+                                                 @PathVariable(name = "blockId") Long blockId) {
+        return new RspTemplate<>(HttpStatus.OK, "블록 상세보기", blockService.findById(email, blockId));
     }
 
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/dto/response/BlockInfoResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/dto/response/BlockInfoResDto.java
@@ -7,7 +7,6 @@ import java.time.temporal.ChronoUnit;
 import lombok.Builder;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
-import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
 @Builder
 public record BlockInfoResDto(
@@ -18,13 +17,13 @@ public record BlockInfoResDto(
         String nickname,
         int dDay
 ) {
-    public static BlockInfoResDto of(Block block, Member member) {
+    public static BlockInfoResDto from(Block block) {
         return BlockInfoResDto.builder()
                 .title(block.getTitle())
                 .contents(block.getContents())
                 .progress(block.getProgress())
                 .deadLine(block.getDeadLine())
-                .nickname(member.getNickname())
+                .nickname(block.getMember().getNickname())
                 .dDay(calculateDDay(block.getDeadLine()))
                 .build();
     }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
@@ -2,8 +2,6 @@ package shop.kkeujeok.kkeujeokbackend.block.application;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -20,77 +18,73 @@ import shop.kkeujeok.kkeujeokbackend.block.exception.InvalidProgressException;
 import shop.kkeujeok.kkeujeokbackend.global.dto.PageInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
+import shop.kkeujeok.kkeujeokbackend.member.exception.MemberNotFoundException;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class BlockService {
-    private static final Logger log = LoggerFactory.getLogger(BlockService.class);
+
     private final MemberRepository memberRepository;
     private final BlockRepository blockRepository;
 
     // 블록 생성
     @Transactional
-    public BlockInfoResDto save(BlockSaveReqDto blockSaveReqDto) {
-        // 로그인/회원가입 코드 완성 후 사용자 정보 받아올 예정
-        Member member = Member.builder().nickname("member").build();
+    public BlockInfoResDto save(String email, BlockSaveReqDto blockSaveReqDto) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Block block = blockRepository.save(blockSaveReqDto.toEntity(member));
 
-        return BlockInfoResDto.of(block, member);
+        return BlockInfoResDto.from(block);
     }
 
     // 블록 수정 (자동 수정 예정)
     @Transactional
-    public BlockInfoResDto update(Long blockId, BlockUpdateReqDto blockUpdateReqDto) {
-        // 로그인/회원가입 코드 완성 후 사용자 정보 받아올 예정
-        Member member = Member.builder().nickname("member").build();
+    public BlockInfoResDto update(String email, Long blockId, BlockUpdateReqDto blockUpdateReqDto) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Block block = blockRepository.findById(blockId).orElseThrow(BlockNotFoundException::new);
 
         block.update(blockUpdateReqDto.title(), blockUpdateReqDto.contents(), blockUpdateReqDto.deadLine());
 
-        return BlockInfoResDto.of(block, member);
+        return BlockInfoResDto.from(block);
     }
 
     // 블록 상태 업데이트 (Progress)
     @Transactional
-    public BlockInfoResDto progressUpdate(Long blockId, String progressString) {
-        // 로그인/회원가입 코드 완성 후 사용자 정보 받아올 예정
-        Member member = Member.builder().nickname("member").build();
+    public BlockInfoResDto progressUpdate(String email, Long blockId, String progressString) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Block block = blockRepository.findById(blockId).orElseThrow(BlockNotFoundException::new);
 
         Progress progress = parseProgress(progressString);
 
         block.progressUpdate(progress);
 
-        return BlockInfoResDto.of(block, member);
+        return BlockInfoResDto.from(block);
     }
 
     // 블록 리스트
-    public BlockListResDto findByBlockWithProgress(String progress, Pageable pageable) {
-        Member member = Member.builder().nickname("member").build();
+    public BlockListResDto findForBlockByProgress(String email, String progress, Pageable pageable) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Page<Block> blocks = blockRepository.findByBlockWithProgress(parseProgress(progress), pageable);
 
         List<BlockInfoResDto> blockInfoResDtoList = blocks.stream()
-                .map(b -> BlockInfoResDto.of(b, member))
+                .map(BlockInfoResDto::from)
                 .toList();
 
         return BlockListResDto.from(blockInfoResDtoList, PageInfoResDto.from(blocks));
     }
 
     // 블록 상세보기
-    public BlockInfoResDto findById(Long blockId) {
-        // 로그인/회원가입 코드 완성 후 사용자 정보 받아올 예정
-        Member member = Member.builder().nickname("member").build();
+    public BlockInfoResDto findById(String email, Long blockId) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Block block = blockRepository.findById(blockId).orElseThrow(BlockNotFoundException::new);
 
-        return BlockInfoResDto.of(block, member);
+        return BlockInfoResDto.from(block);
     }
 
     // 블록 삭제 유무 업데이트 (논리 삭제)
     @Transactional
-    public void delete(Long blockId) {
-        // 로그인/회원가입 코드 완성 후 사용자 정보 받아올 예정
-        Member member = Member.builder().nickname("member").build();
+    public void delete(String email, Long blockId) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Block block = blockRepository.findById(blockId).orElseThrow(BlockNotFoundException::new);
 
         block.statusUpdate();


### PR DESCRIPTION
## #️⃣연관된 이슈

> #11 #18 

## 📝작업 내용

> 컨트롤러에서 이메일을 받습니다. 이메일을 통해 사용자를 받아옵니다. 
컨트롤러 테스트에 Header를 추가합니다.
