### PR TITLE
Feat(#62): Dashboard 도메인 구현, Block에 연관 관계 추가, PersonalDashboard 기능, 테스트 코드 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -7,3 +7,4 @@
 
 include::block.adoc[]
 
+include::peronsalDashboard.adoc[]

--- a/src/docs/asciidoc/peronsalDashboard.adoc
+++ b/src/docs/asciidoc/peronsalDashboard.adoc
@@ -1,0 +1,65 @@
+== 개인 대시보드 API 문서
+
+=== 개인 대시보드 생성 API
+
+==== 요청
+
+include::{snippets}/dashboard/personal/save/http-request.adoc[]
+include::{snippets}/dashboard/personal/save/request-headers.adoc[]
+include::{snippets}/dashboard/personal/save/request-fields.adoc[]
+
+==== 응답
+
+include::{snippets}/dashboard/personal/save/http-response.adoc[]
+include::{snippets}/dashboard/personal/save/response-fields.adoc[]
+
+=== 개인 대시보드 수정 API
+
+==== 요청
+
+include::{snippets}/dashboard/personal/update/http-request.adoc[]
+include::{snippets}/dashboard/personal/update/request-headers.adoc[]
+include::{snippets}/dashboard/personal/update/path-parameters.adoc[]
+include::{snippets}/dashboard/personal/update/request-fields.adoc[]
+
+==== 응답
+
+include::{snippets}/dashboard/personal/update/http-response.adoc[]
+include::{snippets}/dashboard/personal/update/response-fields.adoc[]
+
+=== 개인 대시보드 전체 조회
+
+==== 요청
+
+include::{snippets}/dashboard/personal/findForPersonalDashboard/http-request.adoc[]
+include::{snippets}/dashboard/personal/findForPersonalDashboard/request-headers.adoc[]
+
+==== 응답
+
+include::{snippets}/dashboard/personal/findForPersonalDashboard/http-response.adoc[]
+include::{snippets}/dashboard/personal/findForPersonalDashboard/response-fields.adoc[]
+
+=== 개인 대시보드 상세 조회
+
+==== 요청
+
+include::{snippets}/dashboard/personal/findById/http-request.adoc[]
+include::{snippets}/dashboard/personal/findById/request-headers.adoc[]
+include::{snippets}/dashboard/personal/findById/path-parameters.adoc[]
+
+==== 응답
+
+include::{snippets}/dashboard/personal/findById/http-response.adoc[]
+include::{snippets}/dashboard/personal/findById/response-fields.adoc[]
+
+=== 개인 대시보드 삭제 API
+
+==== 요청
+
+include::{snippets}/dashboard/personal/delete/http-request.adoc[]
+include::{snippets}/dashboard/personal/delete/request-headers.adoc[]
+include::{snippets}/dashboard/personal/delete/path-parameters.adoc[]
+
+==== 응답
+
+include::{snippets}/dashboard/personal/delete/http-response.adoc[]

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockController.java
@@ -28,9 +28,8 @@ public class BlockController {
     private final BlockService blockService;
 
     @PostMapping("/")
-    public RspTemplate<BlockInfoResDto> save(
-            @CurrentUserEmail String email,
-            @RequestBody BlockSaveReqDto blockSaveReqDto) {
+    public RspTemplate<BlockInfoResDto> save(@CurrentUserEmail String email,
+                                             @RequestBody BlockSaveReqDto blockSaveReqDto) {
         return new RspTemplate<>(HttpStatus.CREATED, "블럭 생성", blockService.save(email, blockSaveReqDto));
     }
 

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockController.java
@@ -49,12 +49,13 @@ public class BlockController {
 
     @GetMapping("")
     public RspTemplate<BlockListResDto> findForBlockByProgress(@CurrentUserEmail String email,
+                                                               @RequestParam(name = "dashboardId") Long dashboardId,
                                                                @RequestParam(name = "progress") String progress,
                                                                @RequestParam(name = "page", defaultValue = "0") int page,
                                                                @RequestParam(name = "size", defaultValue = "10") int size) {
         return new RspTemplate<>(HttpStatus.OK,
                 "블록 상태별 전체 조회",
-                blockService.findForBlockByProgress(email, progress, PageRequest.of(page, size)));
+                blockService.findForBlockByProgress(email, dashboardId, progress, PageRequest.of(page, size)));
     }
 
     @DeleteMapping("/{blockId}")

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/dto/request/BlockSaveReqDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/dto/request/BlockSaveReqDto.java
@@ -2,21 +2,24 @@ package shop.kkeujeok.kkeujeokbackend.block.api.dto.request;
 
 import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
+import shop.kkeujeok.kkeujeokbackend.dashboard.domain.Dashboard;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
 public record BlockSaveReqDto(
+        Long dashboardId,
         String title,
         String contents,
         Progress progress,
         String deadLine
 ) {
-    public Block toEntity(Member member) {
+    public Block toEntity(Member member, Dashboard dashboard) {
         return Block.builder()
                 .title(title)
                 .contents(contents)
                 .progress(progress)
                 .deadLine(deadLine)
                 .member(member)
+                .dashboard(dashboard)
                 .build();
     }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/dto/response/BlockInfoResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/dto/response/BlockInfoResDto.java
@@ -10,6 +10,7 @@ import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
 
 @Builder
 public record BlockInfoResDto(
+        Long blockId,
         String title,
         String contents,
         Progress progress,
@@ -19,6 +20,7 @@ public record BlockInfoResDto(
 ) {
     public static BlockInfoResDto from(Block block) {
         return BlockInfoResDto.builder()
+                .blockId(block.getId())
                 .title(block.getTitle())
                 .contents(block.getContents())
                 .progress(block.getProgress())

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
@@ -15,6 +15,9 @@ import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
 import shop.kkeujeok.kkeujeokbackend.block.domain.repository.BlockRepository;
 import shop.kkeujeok.kkeujeokbackend.block.exception.BlockNotFoundException;
 import shop.kkeujeok.kkeujeokbackend.block.exception.InvalidProgressException;
+import shop.kkeujeok.kkeujeokbackend.dashboard.domain.Dashboard;
+import shop.kkeujeok.kkeujeokbackend.dashboard.domain.repository.DashboardRepository;
+import shop.kkeujeok.kkeujeokbackend.dashboard.exception.DashboardNotFoundException;
 import shop.kkeujeok.kkeujeokbackend.global.dto.PageInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
@@ -27,12 +30,15 @@ public class BlockService {
 
     private final MemberRepository memberRepository;
     private final BlockRepository blockRepository;
+    private final DashboardRepository dashboardRepository;
 
     // 블록 생성
     @Transactional
     public BlockInfoResDto save(String email, BlockSaveReqDto blockSaveReqDto) {
         Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
-        Block block = blockRepository.save(blockSaveReqDto.toEntity(member));
+        Dashboard dashboard = dashboardRepository.findById(blockSaveReqDto.dashboardId())
+                .orElseThrow(DashboardNotFoundException::new);
+        Block block = blockRepository.save(blockSaveReqDto.toEntity(member, dashboard));
 
         return BlockInfoResDto.from(block);
     }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
@@ -68,9 +68,9 @@ public class BlockService {
     }
 
     // 블록 리스트
-    public BlockListResDto findForBlockByProgress(String email, String progress, Pageable pageable) {
+    public BlockListResDto findForBlockByProgress(String email, Long dashboardId, String progress, Pageable pageable) {
         Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
-        Page<Block> blocks = blockRepository.findByBlockWithProgress(parseProgress(progress), pageable);
+        Page<Block> blocks = blockRepository.findByBlockWithProgress(dashboardId, parseProgress(progress), pageable);
 
         List<BlockInfoResDto> blockInfoResDtoList = blocks.stream()
                 .map(BlockInfoResDto::from)

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/Block.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/Block.java
@@ -4,12 +4,14 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import shop.kkeujeok.kkeujeokbackend.dashboard.domain.Dashboard;
 import shop.kkeujeok.kkeujeokbackend.global.entity.BaseEntity;
 import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
@@ -36,14 +38,20 @@ public class Block extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dashboard_id")
+    private Dashboard dashboard;
+
     @Builder
-    private Block(String title, String contents, Progress progress, Member member, String deadLine) {
+    private Block(String title, String contents, Progress progress, Member member, String deadLine,
+                  Dashboard dashboard) {
         this.status = Status.ACTIVE;
         this.title = title;
         this.contents = contents;
         this.progress = progress;
         this.deadLine = deadLine;
         this.member = member;
+        this.dashboard = dashboard;
     }
 
     public void update(String updateTitle, String updateContents, String updateDeadLine) {

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockCustomRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockCustomRepository.java
@@ -6,5 +6,5 @@ import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
 
 public interface BlockCustomRepository {
-    Page<Block> findByBlockWithProgress(Progress progress, Pageable pageable);
+    Page<Block> findByBlockWithProgress(Long dashboardId, Progress progress, Pageable pageable);
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockCustomRepositoryImpl.java
@@ -23,7 +23,7 @@ public class BlockCustomRepositoryImpl implements BlockCustomRepository {
     }
 
     @Override
-    public Page<Block> findByBlockWithProgress(Progress progress, Pageable pageable) {
+    public Page<Block> findByBlockWithProgress(Long dashboardId, Progress progress, Pageable pageable) {
         long total = queryFactory
                 .selectFrom(block)
                 .where(block.progress.eq(progress))
@@ -32,7 +32,8 @@ public class BlockCustomRepositoryImpl implements BlockCustomRepository {
 
         List<Block> blocks = queryFactory
                 .selectFrom(block)
-                .where(block.progress.eq(progress)
+                .where(block.dashboard.id.eq(dashboardId)
+                        .and(block.progress.eq(progress))
                         .and(block.status.eq(Status.ACTIVE)))
                 .orderBy(block.id.desc())
                 .offset(pageable.getOffset())

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/Dashboard.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/Dashboard.java
@@ -4,6 +4,8 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
@@ -16,6 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
 import shop.kkeujeok.kkeujeokbackend.global.entity.BaseEntity;
+import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
 @Entity
@@ -24,6 +27,9 @@ import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 @Inheritance(strategy = InheritanceType.JOINED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Dashboard extends BaseEntity {
+
+    @Enumerated(value = EnumType.STRING)
+    private Status status;
 
     private String title;
 
@@ -38,6 +44,7 @@ public class Dashboard extends BaseEntity {
     private List<Block> blocks = new ArrayList<>();
 
     public Dashboard(String title, String description, Member member) {
+        this.status = Status.ACTIVE;
         this.title = title;
         this.description = description;
         this.member = member;
@@ -46,6 +53,10 @@ public class Dashboard extends BaseEntity {
     public void update(String updateTitle, String updateDescription) {
         this.title = updateTitle;
         this.description = updateDescription;
+    }
+
+    public void statusUpdate(Status status) {
+        this.status = status;
     }
 
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/Dashboard.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/Dashboard.java
@@ -1,0 +1,51 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
+import shop.kkeujeok.kkeujeokbackend.global.entity.BaseEntity;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+@Entity
+@Getter
+@DiscriminatorColumn
+@Inheritance(strategy = InheritanceType.JOINED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Dashboard extends BaseEntity {
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToMany(mappedBy = "dashboard", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Block> blocks = new ArrayList<>();
+
+    public Dashboard(String title, String description, Member member) {
+        this.title = title;
+        this.description = description;
+        this.member = member;
+    }
+
+    public void update(String updateTitle, String updateDescription) {
+        this.title = updateTitle;
+        this.description = updateDescription;
+    }
+
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepository.java
@@ -1,0 +1,10 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.domain.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+public interface DashboardCustomRepository {
+    Page<PersonalDashboard> findForPersonalDashboard(Member member, Pageable pageable);
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepository.java
@@ -6,5 +6,9 @@ import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
 public interface DashboardCustomRepository {
+
     Page<PersonalDashboard> findForPersonalDashboard(Member member, Pageable pageable);
+
+    double calculateCompletionPercentage(Long dashboardId);
+    
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepositoryImpl.java
@@ -1,0 +1,42 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.domain.repository;
+
+import static shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.QPersonalDashboard.personalDashboard;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+@Repository
+@Transactional(readOnly = true)
+public class DashboardCustomRepositoryImpl implements DashboardCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public DashboardCustomRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Page<PersonalDashboard> findForPersonalDashboard(Member member, Pageable pageable) {
+        long total = queryFactory
+                .selectFrom(personalDashboard)
+                .where(personalDashboard._super.member.eq(member))
+                .stream()
+                .count();
+
+        List<PersonalDashboard> dashboards = queryFactory
+                .selectFrom(personalDashboard)
+                .where(personalDashboard._super.member.eq(member))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return new PageImpl<>(dashboards, pageable, total);
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package shop.kkeujeok.kkeujeokbackend.dashboard.domain.repository;
 
+import static shop.kkeujeok.kkeujeokbackend.block.domain.QBlock.block;
 import static shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.QPersonalDashboard.personalDashboard;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -9,6 +10,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
@@ -38,5 +40,26 @@ public class DashboardCustomRepositoryImpl implements DashboardCustomRepository 
                 .fetch();
 
         return new PageImpl<>(dashboards, pageable, total);
+    }
+
+    public double calculateCompletionPercentage(Long dashboardId) {
+        long totalBlocks = queryFactory
+                .selectFrom(block)
+                .where(block.dashboard.id.eq(dashboardId))
+                .stream()
+                .count();
+
+        long completedBlocks = queryFactory
+                .select(block)
+                .where(block.dashboard.id.eq(dashboardId)
+                        .and(block.progress.eq(Progress.COMPLETED)))
+                .stream()
+                .count();
+
+        if (totalBlocks == 0) {
+            return 0;
+        }
+
+        return (double) completedBlocks / totalBlocks * 100;
     }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
@@ -43,17 +44,15 @@ public class DashboardCustomRepositoryImpl implements DashboardCustomRepository 
     }
 
     public double calculateCompletionPercentage(Long dashboardId) {
-        long totalBlocks = queryFactory
+        List<Block> blocks = queryFactory
                 .selectFrom(block)
                 .where(block.dashboard.id.eq(dashboardId))
-                .stream()
-                .count();
+                .fetch();
 
-        long completedBlocks = queryFactory
-                .select(block)
-                .where(block.dashboard.id.eq(dashboardId)
-                        .and(block.progress.eq(Progress.COMPLETED)))
-                .stream()
+        long totalBlocks = blocks.size();
+
+        long completedBlocks = blocks.stream()
+                .filter(b -> b.getProgress().equals(Progress.COMPLETED))
                 .count();
 
         if (totalBlocks == 0) {

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardRepository.java
@@ -1,0 +1,7 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.kkeujeok.kkeujeokbackend.dashboard.domain.Dashboard;
+
+public interface DashboardRepository extends JpaRepository<Dashboard, Long> {
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardRepository.java
@@ -3,5 +3,5 @@ package shop.kkeujeok.kkeujeokbackend.dashboard.domain.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.kkeujeok.kkeujeokbackend.dashboard.domain.Dashboard;
 
-public interface DashboardRepository extends JpaRepository<Dashboard, Long> {
+public interface DashboardRepository extends JpaRepository<Dashboard, Long>, DashboardCustomRepository {
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/exception/DashboardNotFoundException.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/exception/DashboardNotFoundException.java
@@ -1,0 +1,14 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.exception;
+
+import shop.kkeujeok.kkeujeokbackend.global.error.exception.NotFoundGroupException;
+
+public class DashboardNotFoundException extends NotFoundGroupException {
+
+    public DashboardNotFoundException(String message) {
+        super(message);
+    }
+
+    public DashboardNotFoundException() {
+        this("존재하지 않는 대시보드 입니다.");
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardController.java
@@ -3,6 +3,7 @@ package shop.kkeujeok.kkeujeokbackend.dashboard.personal.api;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,6 +39,13 @@ public class PersonalDashboardController {
         return new RspTemplate<>(HttpStatus.OK,
                 "개인 대시보드 수정",
                 personalDashboardService.update(email, dashboardId, personalDashboardUpdateReqDto));
+    }
+
+    @DeleteMapping("/{dashboardId}")
+    public RspTemplate<Void> delete(@CurrentUserEmail String email,
+                                    @PathVariable(name = "dashboardId") Long dashboardId) {
+        personalDashboardService.delete(email, dashboardId);
+        return new RspTemplate<>(HttpStatus.OK, "개인 대시보드 삭제");
     }
 
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardController.java
@@ -1,5 +1,6 @@
 package shop.kkeujeok.kkeujeokbackend.dashboard.personal.api;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -24,7 +25,7 @@ public class PersonalDashboardController {
 
     @PostMapping("/")
     public RspTemplate<PersonalDashboardInfoResDto> save(@CurrentUserEmail String email,
-                                                         @RequestBody PersonalDashboardSaveReqDto personalDashboardSaveReqDto) {
+                                                         @RequestBody @Valid PersonalDashboardSaveReqDto personalDashboardSaveReqDto) {
         return new RspTemplate<>(HttpStatus.OK,
                 "개인 대시보드 생성",
                 personalDashboardService.save(email, personalDashboardSaveReqDto));

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardController.java
@@ -1,0 +1,42 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.personal.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request.PersonalDashboardSaveReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request.PersonalDashboardUpdateReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.response.PersonalDashboardInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.application.PersonalDashboardService;
+import shop.kkeujeok.kkeujeokbackend.global.annotation.CurrentUserEmail;
+import shop.kkeujeok.kkeujeokbackend.global.template.RspTemplate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/dashboards")
+public class PersonalDashboardController {
+
+    private final PersonalDashboardService personalDashboardService;
+
+    @PostMapping("/")
+    public RspTemplate<PersonalDashboardInfoResDto> save(@CurrentUserEmail String email,
+                                                         @RequestBody PersonalDashboardSaveReqDto personalDashboardSaveReqDto) {
+        return new RspTemplate<>(HttpStatus.OK,
+                "개인 대시보드 생성",
+                personalDashboardService.save(email, personalDashboardSaveReqDto));
+    }
+
+    @PatchMapping("/{dashboardId}")
+    public RspTemplate<PersonalDashboardInfoResDto> update(@CurrentUserEmail String email,
+                                                           @PathVariable(name = "dashboardId") Long dashboardId,
+                                                           @RequestBody PersonalDashboardUpdateReqDto personalDashboardUpdateReqDto) {
+        return new RspTemplate<>(HttpStatus.OK,
+                "개인 대시보드 수정",
+                personalDashboardService.update(email, dashboardId, personalDashboardUpdateReqDto));
+    }
+
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardController.java
@@ -2,24 +2,28 @@ package shop.kkeujeok.kkeujeokbackend.dashboard.personal.api;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request.PersonalDashboardSaveReqDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request.PersonalDashboardUpdateReqDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.response.PersonalDashboardInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.response.PersonalDashboardListResDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.application.PersonalDashboardService;
 import shop.kkeujeok.kkeujeokbackend.global.annotation.CurrentUserEmail;
 import shop.kkeujeok.kkeujeokbackend.global.template.RspTemplate;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/dashboards")
+@RequestMapping("/api/dashboards/personal")
 public class PersonalDashboardController {
 
     private final PersonalDashboardService personalDashboardService;
@@ -39,6 +43,21 @@ public class PersonalDashboardController {
         return new RspTemplate<>(HttpStatus.OK,
                 "개인 대시보드 수정",
                 personalDashboardService.update(email, dashboardId, personalDashboardUpdateReqDto));
+    }
+
+    @GetMapping("/")
+    public RspTemplate<PersonalDashboardListResDto> findForPersonalDashboard(@CurrentUserEmail String email,
+                                                                             @RequestParam(name = "page", defaultValue = "0") int page,
+                                                                             @RequestParam(name = "size", defaultValue = "10") int size) {
+        return new RspTemplate<>(HttpStatus.OK,
+                "개인 대시보드 전체 조회",
+                personalDashboardService.findForPersonalDashboard(email, PageRequest.of(page, size)));
+    }
+
+    @GetMapping("/{dashboardId}")
+    public RspTemplate<PersonalDashboardInfoResDto> findById(@CurrentUserEmail String email,
+                                                             @PathVariable(name = "dashboardId") Long dashboardId) {
+        return new RspTemplate<>(HttpStatus.OK, "개인 대시보드 상세보기", personalDashboardService.findById(email, dashboardId));
     }
 
     @DeleteMapping("/{dashboardId}")

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/request/PersonalDashboardSaveReqDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/request/PersonalDashboardSaveReqDto.java
@@ -1,0 +1,21 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request;
+
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+public record PersonalDashboardSaveReqDto(
+        String title,
+        String description,
+        boolean isPublic,
+        String category
+) {
+    public PersonalDashboard toEntity(Member member) {
+        return PersonalDashboard.builder()
+                .title(title)
+                .description(description)
+                .member(member)
+                .isPublic(isPublic)
+                .category(category)
+                .build();
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/request/PersonalDashboardSaveReqDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/request/PersonalDashboardSaveReqDto.java
@@ -1,7 +1,7 @@
 package shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request;
 
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
@@ -10,11 +10,11 @@ public record PersonalDashboardSaveReqDto(
         String title,
 
         @NotBlank(message = "필수 입력값 입니다.")
-        @Max(value = 300)
+        @Size(max = 300)
         String description,
 
         boolean isPublic,
-        
+
         String category
 ) {
     public PersonalDashboard toEntity(Member member) {

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/request/PersonalDashboardSaveReqDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/request/PersonalDashboardSaveReqDto.java
@@ -1,12 +1,20 @@
 package shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
 public record PersonalDashboardSaveReqDto(
+        @NotBlank(message = "필수 입력값 입니다.")
         String title,
+
+        @NotBlank(message = "필수 입력값 입니다.")
+        @Max(value = 300)
         String description,
+
         boolean isPublic,
+        
         String category
 ) {
     public PersonalDashboard toEntity(Member member) {

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/request/PersonalDashboardUpdateReqDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/request/PersonalDashboardUpdateReqDto.java
@@ -1,0 +1,8 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request;
+
+public record PersonalDashboardUpdateReqDto(
+        String title,
+        String description,
+        String category
+) {
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/request/PersonalDashboardUpdateReqDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/request/PersonalDashboardUpdateReqDto.java
@@ -3,6 +3,7 @@ package shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request;
 public record PersonalDashboardUpdateReqDto(
         String title,
         String description,
+        boolean isPublic,
         String category
 ) {
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/response/PersonalDashboardInfoResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/response/PersonalDashboardInfoResDto.java
@@ -1,0 +1,21 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.response;
+
+import lombok.Builder;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
+
+@Builder
+public record PersonalDashboardInfoResDto(
+        String title,
+        String description,
+        boolean isPublic,
+        String category
+) {
+    public static PersonalDashboardInfoResDto from(PersonalDashboard dashboard) {
+        return PersonalDashboardInfoResDto.builder()
+                .title(dashboard.getTitle())
+                .description(dashboard.getDescription())
+                .isPublic(dashboard.isPublic())
+                .category(dashboard.getCategory())
+                .build();
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/response/PersonalDashboardInfoResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/response/PersonalDashboardInfoResDto.java
@@ -2,16 +2,23 @@ package shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.response;
 
 import lombok.Builder;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
 @Builder
 public record PersonalDashboardInfoResDto(
+        Long dashboardId,
+        Long myId,
+        Long creatorId,
         String title,
         String description,
         boolean isPublic,
         String category
 ) {
-    public static PersonalDashboardInfoResDto from(PersonalDashboard dashboard) {
+    public static PersonalDashboardInfoResDto of(Member member, PersonalDashboard dashboard) {
         return PersonalDashboardInfoResDto.builder()
+                .dashboardId(dashboard.getId())
+                .myId(member.getId())
+                .creatorId(dashboard.getMember().getId())
                 .title(dashboard.getTitle())
                 .description(dashboard.getDescription())
                 .isPublic(dashboard.isPublic())

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/response/PersonalDashboardInfoResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/response/PersonalDashboardInfoResDto.java
@@ -12,9 +12,24 @@ public record PersonalDashboardInfoResDto(
         String title,
         String description,
         boolean isPublic,
-        String category
+        String category,
+        double blockProgress
 ) {
     public static PersonalDashboardInfoResDto of(Member member, PersonalDashboard dashboard) {
+        return commonBuilder(member, dashboard)
+                .build();
+    }
+
+    public static PersonalDashboardInfoResDto detailOf(Member member,
+                                                       PersonalDashboard dashboard,
+                                                       double blockProgress) {
+        return commonBuilder(member, dashboard)
+                .blockProgress(blockProgress)
+                .build();
+    }
+
+    private static PersonalDashboardInfoResDtoBuilder commonBuilder(Member member,
+                                                                    PersonalDashboard dashboard) {
         return PersonalDashboardInfoResDto.builder()
                 .dashboardId(dashboard.getId())
                 .myId(member.getId())
@@ -22,7 +37,7 @@ public record PersonalDashboardInfoResDto(
                 .title(dashboard.getTitle())
                 .description(dashboard.getDescription())
                 .isPublic(dashboard.isPublic())
-                .category(dashboard.getCategory())
-                .build();
+                .category(dashboard.getCategory());
     }
+
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/response/PersonalDashboardListResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/response/PersonalDashboardListResDto.java
@@ -1,0 +1,19 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import shop.kkeujeok.kkeujeokbackend.global.dto.PageInfoResDto;
+
+@Builder
+public record PersonalDashboardListResDto(
+        List<PersonalDashboardInfoResDto> personalDashboardListResDto,
+        PageInfoResDto pageInfoResDto
+) {
+    public static PersonalDashboardListResDto from(List<PersonalDashboardInfoResDto> personalDashboards,
+                                                   PageInfoResDto pageInfoResDto) {
+        return PersonalDashboardListResDto.builder()
+                .personalDashboardListResDto(personalDashboards)
+                .pageInfoResDto(pageInfoResDto)
+                .build();
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
@@ -46,6 +46,7 @@ public class PersonalDashboardService {
 
         dashboard.update(personalDashboardUpdateReqDto.title(),
                 personalDashboardUpdateReqDto.description(),
+                personalDashboardUpdateReqDto.isPublic(),
                 personalDashboardUpdateReqDto.category());
 
         return PersonalDashboardInfoResDto.from(dashboard);

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
@@ -1,15 +1,20 @@
 package shop.kkeujeok.kkeujeokbackend.dashboard.personal.application;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.kkeujeok.kkeujeokbackend.dashboard.exception.DashboardNotFoundException;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request.PersonalDashboardSaveReqDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request.PersonalDashboardUpdateReqDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.response.PersonalDashboardInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.response.PersonalDashboardListResDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.repository.PersonalDashboardRepository;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.exception.DashboardAccessDeniedException;
+import shop.kkeujeok.kkeujeokbackend.global.dto.PageInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
 import shop.kkeujeok.kkeujeokbackend.member.exception.MemberNotFoundException;
@@ -30,7 +35,7 @@ public class PersonalDashboardService {
 
         personalDashboardRepository.save(dashboard);
 
-        return PersonalDashboardInfoResDto.from(dashboard);
+        return PersonalDashboardInfoResDto.of(member, dashboard);
     }
 
     // 개인 대시보드 수정
@@ -49,7 +54,30 @@ public class PersonalDashboardService {
                 personalDashboardUpdateReqDto.isPublic(),
                 personalDashboardUpdateReqDto.category());
 
-        return PersonalDashboardInfoResDto.from(dashboard);
+        return PersonalDashboardInfoResDto.of(member, dashboard);
+    }
+
+    // 개인 대시보드 전체 조회
+    public PersonalDashboardListResDto findForPersonalDashboard(String email, Pageable pageable) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        Page<PersonalDashboard> personalDashboards = personalDashboardRepository.
+                findForPersonalDashboard(member, pageable);
+
+        List<PersonalDashboardInfoResDto> personalDashboardInfoResDtoList = personalDashboards.stream()
+                .map(p -> PersonalDashboardInfoResDto.of(member, p))
+                .toList();
+
+        return PersonalDashboardListResDto
+                .from(personalDashboardInfoResDtoList, PageInfoResDto.from(personalDashboards));
+    }
+
+    // 개인 대시보드 상세조회
+    public PersonalDashboardInfoResDto findById(String email, Long dashboardId) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        PersonalDashboard dashboard = personalDashboardRepository.findById(dashboardId)
+                .orElseThrow(DashboardNotFoundException::new);
+
+        return PersonalDashboardInfoResDto.of(member, dashboard);
     }
 
     // 개인 대시보드 삭제 유무 업데이트 (논리 삭제)

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
@@ -52,6 +52,16 @@ public class PersonalDashboardService {
         return PersonalDashboardInfoResDto.from(dashboard);
     }
 
+    // 개인 대시보드 삭제 유무 업데이트 (논리 삭제)
+    @Transactional
+    public void delete(String email, Long dashboardId) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        PersonalDashboard dashboard = personalDashboardRepository.findById(dashboardId)
+                .orElseThrow(DashboardNotFoundException::new);
+
+        dashboard.statusUpdate();
+    }
+
     private void verifyMemberIsAuthor(PersonalDashboard dashboard, Member member) {
         if (!member.equals(dashboard.getMember())) {
             throw new DashboardAccessDeniedException();

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
@@ -1,0 +1,60 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.personal.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.kkeujeok.kkeujeokbackend.dashboard.exception.DashboardNotFoundException;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request.PersonalDashboardSaveReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request.PersonalDashboardUpdateReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.response.PersonalDashboardInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.repository.PersonalDashboardRepository;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.exception.DashboardAccessDeniedException;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
+import shop.kkeujeok.kkeujeokbackend.member.exception.MemberNotFoundException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PersonalDashboardService {
+
+    private final PersonalDashboardRepository personalDashboardRepository;
+    private final MemberRepository memberRepository;
+
+    // 개인 대시보드 저장
+    @Transactional
+    public PersonalDashboardInfoResDto save(String email, PersonalDashboardSaveReqDto personalDashboardSaveReqDto) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        PersonalDashboard dashboard = personalDashboardSaveReqDto.toEntity(member);
+
+        personalDashboardRepository.save(dashboard);
+
+        return PersonalDashboardInfoResDto.from(dashboard);
+    }
+
+    // 개인 대시보드 수정
+    @Transactional
+    public PersonalDashboardInfoResDto update(String email,
+                                              Long dashboardId,
+                                              PersonalDashboardUpdateReqDto personalDashboardUpdateReqDto) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        PersonalDashboard dashboard = personalDashboardRepository.findById(dashboardId)
+                .orElseThrow(DashboardNotFoundException::new);
+
+        verifyMemberIsAuthor(dashboard, member);
+
+        dashboard.update(personalDashboardUpdateReqDto.title(),
+                personalDashboardUpdateReqDto.description(),
+                personalDashboardUpdateReqDto.category());
+
+        return PersonalDashboardInfoResDto.from(dashboard);
+    }
+
+    private void verifyMemberIsAuthor(PersonalDashboard dashboard, Member member) {
+        if (!member.equals(dashboard.getMember())) {
+            throw new DashboardAccessDeniedException();
+        }
+    }
+
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
@@ -77,7 +77,9 @@ public class PersonalDashboardService {
         PersonalDashboard dashboard = personalDashboardRepository.findById(dashboardId)
                 .orElseThrow(DashboardNotFoundException::new);
 
-        return PersonalDashboardInfoResDto.of(member, dashboard);
+        double blockProgress = personalDashboardRepository.calculateCompletionPercentage(dashboard.getId());
+
+        return PersonalDashboardInfoResDto.detailOf(member, dashboard, blockProgress);
     }
 
     // 개인 대시보드 삭제 유무 업데이트 (논리 삭제)

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/domain/PersonalDashboard.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/domain/PersonalDashboard.java
@@ -24,8 +24,9 @@ public class PersonalDashboard extends Dashboard {
         this.isPublic = isPublic;
     }
 
-    public void update(String updateTitle, String updateDescription, String updateCategory) {
+    public void update(String updateTitle, String updateDescription, boolean updateIsPublic, String updateCategory) {
         super.update(updateTitle, updateDescription);
+        this.isPublic = updateIsPublic;
         this.category = updateCategory;
     }
 

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/domain/PersonalDashboard.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/domain/PersonalDashboard.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import shop.kkeujeok.kkeujeokbackend.dashboard.domain.Dashboard;
+import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
 @Entity
@@ -28,6 +29,10 @@ public class PersonalDashboard extends Dashboard {
         super.update(updateTitle, updateDescription);
         this.isPublic = updateIsPublic;
         this.category = updateCategory;
+    }
+
+    public void statusUpdate() {
+        super.statusUpdate((super.getStatus() == Status.ACTIVE) ? Status.DELETED : Status.ACTIVE);
     }
 
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/domain/PersonalDashboard.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/domain/PersonalDashboard.java
@@ -1,0 +1,32 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain;
+
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import shop.kkeujeok.kkeujeokbackend.dashboard.domain.Dashboard;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PersonalDashboard extends Dashboard {
+
+    public boolean isPublic;
+
+    private String category;
+
+    @Builder
+    private PersonalDashboard(String title, String description, Member member, boolean isPublic, String category) {
+        super(title, description, member);
+        this.category = category;
+        this.isPublic = isPublic;
+    }
+
+    public void update(String updateTitle, String updateDescription, String updateCategory) {
+        super.update(updateTitle, updateDescription);
+        this.category = updateCategory;
+    }
+
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/domain/repository/PersonalDashboardRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/domain/repository/PersonalDashboardRepository.java
@@ -1,0 +1,8 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
+
+public interface PersonalDashboardRepository extends JpaRepository<PersonalDashboard, Long> {
+
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/domain/repository/PersonalDashboardRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/domain/repository/PersonalDashboardRepository.java
@@ -1,8 +1,9 @@
 package shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import shop.kkeujeok.kkeujeokbackend.dashboard.domain.repository.DashboardCustomRepository;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
 
-public interface PersonalDashboardRepository extends JpaRepository<PersonalDashboard, Long> {
+public interface PersonalDashboardRepository extends JpaRepository<PersonalDashboard, Long>, DashboardCustomRepository {
 
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/exception/DashboardAccessDeniedException.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/exception/DashboardAccessDeniedException.java
@@ -1,0 +1,13 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.personal.exception;
+
+import shop.kkeujeok.kkeujeokbackend.global.error.exception.AccessDeniedGroupException;
+
+public class DashboardAccessDeniedException extends AccessDeniedGroupException {
+    public DashboardAccessDeniedException(String message) {
+        super(message);
+    }
+
+    public DashboardAccessDeniedException() {
+        this("대시보드 생성자가 아닙니다.");
+    }
+}

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockControllerTest.java
@@ -49,6 +49,8 @@ import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
 import shop.kkeujeok.kkeujeokbackend.block.exception.InvalidProgressException;
 import shop.kkeujeok.kkeujeokbackend.common.annotation.ControllerTest;
+import shop.kkeujeok.kkeujeokbackend.dashboard.domain.Dashboard;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
 import shop.kkeujeok.kkeujeokbackend.global.annotationresolver.CurrentUserEmailArgumentResolver;
 import shop.kkeujeok.kkeujeokbackend.global.dto.PageInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.global.error.ControllerAdvice;
@@ -77,9 +79,17 @@ class BlockControllerTest extends ControllerTest {
                 .picture("picture")
                 .build();
 
-        blockSaveReqDto = new BlockSaveReqDto("Title", "Contents", Progress.NOT_STARTED, "2024.08.03 13:23");
+        Dashboard dashboard = PersonalDashboard.builder()
+                .member(member)
+                .title("title")
+                .description("description")
+                .isPublic(false)
+                .category("category")
+                .build();
+
+        blockSaveReqDto = new BlockSaveReqDto(1L, "Title", "Contents", Progress.NOT_STARTED, "2024.08.03 13:23");
         blockUpdateReqDto = new BlockUpdateReqDto("UpdateTitle", "UpdateContents", "2024.07.28 16:40");
-        block = blockSaveReqDto.toEntity(member);
+        block = blockSaveReqDto.toEntity(member, dashboard);
 
         blockController = new BlockController(blockService);
 
@@ -113,6 +123,7 @@ class BlockControllerTest extends ControllerTest {
                                 headerWithName("Authorization").description("JWT 토큰")
                         ),
                         requestFields(
+                                fieldWithPath("dashboardId").description("대시보드 아이디"),
                                 fieldWithPath("title").description("블록 제목"),
                                 fieldWithPath("contents").description("블록 내용"),
                                 fieldWithPath("progress").description("블록 진행 상태"),

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockControllerTest.java
@@ -31,14 +31,12 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import shop.kkeujeok.kkeujeokbackend.auth.api.dto.request.TokenReqDto;
 import shop.kkeujeok.kkeujeokbackend.block.api.dto.request.BlockSaveReqDto;
@@ -57,7 +55,6 @@ import shop.kkeujeok.kkeujeokbackend.global.error.ControllerAdvice;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.domain.SocialType;
 
-@ExtendWith(RestDocumentationExtension.class)
 class BlockControllerTest extends ControllerTest {
 
     private Member member;

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockControllerTest.java
@@ -129,6 +129,7 @@ class BlockControllerTest extends ControllerTest {
                         responseFields(
                                 fieldWithPath("statusCode").description("상태 코드"),
                                 fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.blockId").description("블록 아이디"),
                                 fieldWithPath("data.title").description("블록 제목"),
                                 fieldWithPath("data.contents").description("블록 내용"),
                                 fieldWithPath("data.progress").description("블록 진행 상태"),
@@ -169,6 +170,7 @@ class BlockControllerTest extends ControllerTest {
                         responseFields(
                                 fieldWithPath("statusCode").description("상태 코드"),
                                 fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.blockId").description("블록 아이디"),
                                 fieldWithPath("data.title").description("블록 제목"),
                                 fieldWithPath("data.contents").description("블록 내용"),
                                 fieldWithPath("data.progress").description("블록 진행 상태"),
@@ -208,6 +210,7 @@ class BlockControllerTest extends ControllerTest {
                         responseFields(
                                 fieldWithPath("statusCode").description("상태 코드"),
                                 fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.blockId").description("블록 아이디"),
                                 fieldWithPath("data.title").description("블록 제목"),
                                 fieldWithPath("data.contents").description("블록 내용"),
                                 fieldWithPath("data.progress").description("블록 진행 상태"),
@@ -280,10 +283,10 @@ class BlockControllerTest extends ControllerTest {
                 Collections.singletonList(BlockInfoResDto.from(block)),
                 PageInfoResDto.from(blockPage));
 
-        given(blockService.findForBlockByProgress(anyString(), anyString(), any())).willReturn(response);
+        given(blockService.findForBlockByProgress(anyString(), anyLong(), anyString(), any())).willReturn(response);
 
         // when & then
-        mockMvc.perform(get(String.format("/api/blocks?progress=%s", progressString))
+        mockMvc.perform(get(String.format("/api/blocks?dashboardId=%d&progress=%s", 1L, progressString))
                         .header("Authorization", "Bearer valid-token")
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
@@ -291,12 +294,15 @@ class BlockControllerTest extends ControllerTest {
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         queryParameters(
+                                parameterWithName("dashboardId")
+                                        .description("대시보드 아이디"),
                                 parameterWithName("progress")
                                         .description("블록 상태 문자열(NOT_STARTED, IN_PROGRESS, COMPLETED)")
                         ),
                         responseFields(
                                 fieldWithPath("statusCode").description("상태 코드"),
                                 fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.blockListResDto[].blockId").description("블록 아이디"),
                                 fieldWithPath("data.blockListResDto[].title").description("블록 제목"),
                                 fieldWithPath("data.blockListResDto[].contents").description("블록 내용"),
                                 fieldWithPath("data.blockListResDto[].progress").description("블록 진행 상태"),
@@ -333,6 +339,7 @@ class BlockControllerTest extends ControllerTest {
                         responseFields(
                                 fieldWithPath("statusCode").description("상태 코드"),
                                 fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.blockId").description("블록 아이디"),
                                 fieldWithPath("data.title").description("블록 제목"),
                                 fieldWithPath("data.contents").description("블록 내용"),
                                 fieldWithPath("data.progress").description("블록 진행 상태"),

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockServiceTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -23,6 +24,9 @@ import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
 import shop.kkeujeok.kkeujeokbackend.block.domain.repository.BlockRepository;
 import shop.kkeujeok.kkeujeokbackend.block.exception.InvalidProgressException;
+import shop.kkeujeok.kkeujeokbackend.dashboard.domain.Dashboard;
+import shop.kkeujeok.kkeujeokbackend.dashboard.domain.repository.DashboardRepository;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
 import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.domain.SocialType;
@@ -37,12 +41,16 @@ class BlockServiceTest {
     @Mock
     private MemberRepository memberRepository;
 
+    @Mock
+    private DashboardRepository dashboardRepository;
+
     @InjectMocks
     private BlockService blockService;
 
     private Member member;
     private Block block;
     private Block deleteBlock;
+    private Dashboard dashboard;
     private BlockSaveReqDto blockSaveReqDto;
     private BlockUpdateReqDto blockUpdateReqDto;
 
@@ -58,8 +66,16 @@ class BlockServiceTest {
                 .build();
 
         when(memberRepository.findByEmail(anyString())).thenReturn(Optional.ofNullable(member));
-        
-        blockSaveReqDto = new BlockSaveReqDto("Title", "Contents", Progress.NOT_STARTED, "2024.07.25 13:23");
+
+        dashboard = PersonalDashboard.builder()
+                .member(member)
+                .title("title")
+                .description("description")
+                .isPublic(false)
+                .category("category")
+                .build();
+
+        blockSaveReqDto = new BlockSaveReqDto(1L, "Title", "Contents", Progress.NOT_STARTED, "2024.07.25 13:23");
         blockUpdateReqDto = new BlockUpdateReqDto("UpdateTitle", "UpdateContents", "2024.07.28 16:40");
         block = Block.builder()
                 .title(blockSaveReqDto.title())
@@ -67,6 +83,7 @@ class BlockServiceTest {
                 .progress(blockSaveReqDto.progress())
                 .deadLine(blockSaveReqDto.deadLine())
                 .member(member)
+                .dashboard(dashboard)
                 .build();
 
         deleteBlock = Block.builder()
@@ -75,6 +92,7 @@ class BlockServiceTest {
                 .progress(blockSaveReqDto.progress())
                 .deadLine(blockSaveReqDto.deadLine())
                 .member(member)
+                .dashboard(dashboard)
                 .build();
         deleteBlock.statusUpdate();
     }
@@ -84,6 +102,7 @@ class BlockServiceTest {
     void 블록_저장() {
         // given
         when(blockRepository.save(any(Block.class))).thenReturn(block);
+        when(dashboardRepository.findById(anyLong())).thenReturn(Optional.of(dashboard));
 
         // when
         BlockInfoResDto result = blockService.save("email", blockSaveReqDto);

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockRepositoryTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockRepositoryTest.java
@@ -3,6 +3,7 @@ package shop.kkeujeok.kkeujeokbackend.block.domain.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,8 +15,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
+import shop.kkeujeok.kkeujeokbackend.dashboard.domain.Dashboard;
+import shop.kkeujeok.kkeujeokbackend.dashboard.domain.repository.DashboardRepository;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
 import shop.kkeujeok.kkeujeokbackend.global.config.JpaAuditingConfig;
 import shop.kkeujeok.kkeujeokbackend.global.config.QuerydslConfig;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.domain.SocialType;
+import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
 
 @DataJpaTest
 @Import({JpaAuditingConfig.class, QuerydslConfig.class})
@@ -23,42 +30,80 @@ import shop.kkeujeok.kkeujeokbackend.global.config.QuerydslConfig;
 class BlockRepositoryTest {
 
     @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
     private BlockRepository blockRepository;
+
+    @Autowired
+    private DashboardRepository dashboardRepository;
+
+    private Member member;
+    private Dashboard dashboard;
+    private Block block1;
+    private Block block2;
+    private Block block3;
+
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .email("email")
+                .name("name")
+                .nickname("nickname")
+                .socialType(SocialType.GOOGLE)
+                .introduction("introduction")
+                .picture("picture")
+                .build();
+
+        dashboard = PersonalDashboard.builder()
+                .member(member)
+                .title("title")
+                .description("description")
+                .isPublic(false)
+                .category("category")
+                .build();
+
+        block1 = Block.builder()
+                .title("title1")
+                .contents("contents1")
+                .progress(Progress.NOT_STARTED)
+                .deadLine("2024.07.27 11:03")
+                .dashboard(dashboard)
+                .build();
+
+        block2 = Block.builder()
+                .title("title2")
+                .contents("contents2")
+                .progress(Progress.NOT_STARTED)
+                .deadLine("2024.07.27 11:04")
+                .dashboard(dashboard)
+                .build();
+
+        block3 = Block.builder()
+                .title("title3")
+                .contents("contents3")
+                .progress(Progress.IN_PROGRESS)
+                .deadLine("2024.07.27 11:05")
+                .dashboard(dashboard)
+                .build();
+
+        memberRepository.save(member);
+        dashboardRepository.save(dashboard);
+        blockRepository.save(block1);
+        blockRepository.save(block2);
+        blockRepository.save(block3);
+    }
 
     @DisplayName("블록을 진행 상태별로 전체 조회합니다.")
     @Test
     void 블록_진행_상태_전체_조회() {
         // given
-        Block block1 = Block.builder()
-                .title("title1")
-                .contents("contents1")
-                .progress(Progress.NOT_STARTED)
-                .deadLine("2024.07.27 11:03")
-                .build();
-
-        Block block2 = Block.builder()
-                .title("title2")
-                .contents("contents2")
-                .progress(Progress.NOT_STARTED)
-                .deadLine("2024.07.27 11:04")
-                .build();
-
-        Block block3 = Block.builder()
-                .title("title3")
-                .contents("contents3")
-                .progress(Progress.IN_PROGRESS)
-                .deadLine("2024.07.27 11:05")
-                .build();
-
-        blockRepository.save(block1);
-        blockRepository.save(block2);
-        blockRepository.save(block3);
-
         Progress progress = Progress.NOT_STARTED;
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        Page<Block> blocks = blockRepository.findByBlockWithProgress(progress, pageable);
+        Page<Block> blocks = blockRepository.findByBlockWithProgress(dashboard.getId(), progress, pageable);
 
         // then
         assertThat(blocks.getContent().size()).isEqualTo(2);
@@ -68,37 +113,12 @@ class BlockRepositoryTest {
     @Test
     void 블록_삭제_상태_전체_조회() {
         // given
-        Block block1 = Block.builder()
-                .title("title1")
-                .contents("contents1")
-                .progress(Progress.NOT_STARTED)
-                .deadLine("2024.07.27 11:03")
-                .build();
-
-        Block block2 = Block.builder()
-                .title("title2")
-                .contents("contents2")
-                .progress(Progress.NOT_STARTED)
-                .deadLine("2024.07.27 11:04")
-                .build();
-
-        Block block3 = Block.builder()
-                .title("title3")
-                .contents("contents3")
-                .progress(Progress.IN_PROGRESS)
-                .deadLine("2024.07.27 11:05")
-                .build();
-
-        blockRepository.save(block1);
-        blockRepository.save(block2);
-        blockRepository.save(block3);
-
         Progress progress = Progress.NOT_STARTED;
         Pageable pageable = PageRequest.of(0, 10);
         block1.statusUpdate();
 
         // when
-        Page<Block> blocks = blockRepository.findByBlockWithProgress(progress, pageable);
+        Page<Block> blocks = blockRepository.findByBlockWithProgress(1L, progress, pageable);
 
         // then
         assertThat(blocks.getContent().size()).isEqualTo(1);

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/common/annotation/ControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/common/annotation/ControllerTest.java
@@ -1,11 +1,13 @@
 package shop.kkeujeok.kkeujeokbackend.common.annotation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import shop.kkeujeok.kkeujeokbackend.auth.api.AuthController;
@@ -17,6 +19,7 @@ import shop.kkeujeok.kkeujeokbackend.block.api.BlockController;
 import shop.kkeujeok.kkeujeokbackend.block.application.BlockService;
 import shop.kkeujeok.kkeujeokbackend.challenge.api.ChallengeController;
 import shop.kkeujeok.kkeujeokbackend.challenge.application.ChallengeService;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.application.PersonalDashboardService;
 import shop.kkeujeok.kkeujeokbackend.global.jwt.TokenProvider;
 
 @AutoConfigureRestDocs
@@ -25,6 +28,7 @@ import shop.kkeujeok.kkeujeokbackend.global.jwt.TokenProvider;
         AuthController.class,
         ChallengeController.class
 })
+@ExtendWith(RestDocumentationExtension.class)
 @ActiveProfiles("test")
 public abstract class ControllerTest {
 
@@ -36,6 +40,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected BlockService blockService;
+
+    @MockBean
+    protected PersonalDashboardService personalDashboardService;
 
     @MockBean
     protected TokenProvider tokenProvider;

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardControllerTest.java
@@ -1,0 +1,163 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.personal.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static shop.kkeujeok.kkeujeokbackend.global.restdocs.RestDocsHandler.requestFields;
+import static shop.kkeujeok.kkeujeokbackend.global.restdocs.RestDocsHandler.responseFields;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import shop.kkeujeok.kkeujeokbackend.auth.api.dto.request.TokenReqDto;
+import shop.kkeujeok.kkeujeokbackend.common.annotation.ControllerTest;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request.PersonalDashboardSaveReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request.PersonalDashboardUpdateReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.response.PersonalDashboardInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
+import shop.kkeujeok.kkeujeokbackend.global.annotationresolver.CurrentUserEmailArgumentResolver;
+import shop.kkeujeok.kkeujeokbackend.global.error.ControllerAdvice;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.domain.SocialType;
+
+class PersonalDashboardControllerTest extends ControllerTest {
+
+    private Member member;
+    private PersonalDashboard personalDashboard;
+    private PersonalDashboardSaveReqDto personalDashboardSaveReqDto;
+    private PersonalDashboardUpdateReqDto personalDashboardUpdateReqDto;
+
+    @InjectMocks
+    private PersonalDashboardController personalDashboardController;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        member = Member.builder()
+                .email("email")
+                .name("name")
+                .nickname("nickname")
+                .socialType(SocialType.GOOGLE)
+                .introduction("introduction")
+                .picture("picture")
+                .build();
+
+        personalDashboardSaveReqDto = new PersonalDashboardSaveReqDto("title", "description", false, "category");
+        personalDashboardUpdateReqDto = new PersonalDashboardUpdateReqDto("updateTitle", "updateDescription", true,
+                "updateCategory");
+        personalDashboard = personalDashboardSaveReqDto.toEntity(member);
+
+        personalDashboardController = new PersonalDashboardController(personalDashboardService);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(personalDashboardController)
+                .apply(documentationConfiguration(restDocumentation))
+                .setCustomArgumentResolvers(new CurrentUserEmailArgumentResolver(tokenProvider))
+                .setControllerAdvice(new ControllerAdvice())
+                .build();
+
+        when(tokenProvider.getUserEmailFromToken(any(TokenReqDto.class))).thenReturn("email");
+    }
+
+    @DisplayName("POST 개인 대시보드 저장 컨트롤러 로직 확인")
+    @Test
+    void 개인_대시보드_저장() throws Exception {
+        // given
+        PersonalDashboardInfoResDto response = PersonalDashboardInfoResDto.from(personalDashboard);
+        given(personalDashboardService.save(anyString(), any(PersonalDashboardSaveReqDto.class))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/dashboards/")
+                        .header("Authorization", "Bearer valid-token")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(personalDashboardSaveReqDto)))
+                .andDo(print())
+                .andDo(document("dashboard/save",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").description("개인 대시보드 제목"),
+                                fieldWithPath("description").description("개인 대시보드 설명"),
+                                fieldWithPath("isPublic").description("개인 대시보드 공개 범위"),
+                                fieldWithPath("category").description("개인 대시보드 카테고리")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.title").description("개인 대시보드 제목"),
+                                fieldWithPath("data.description").description("개인 대시보드 설명"),
+                                fieldWithPath("data.isPublic").description("개인 대시보드 공개 범위"),
+                                fieldWithPath("data.category").description("개인 대시보드 카테고리")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("PATCH 개인 대시보드 수정 컨트롤러 로직 확인")
+    @Test
+    void 개인_대시보드_수정() throws Exception {
+        // given
+        personalDashboard.update(personalDashboardUpdateReqDto.title(),
+                personalDashboardUpdateReqDto.description(),
+                personalDashboardUpdateReqDto.isPublic(),
+                personalDashboardUpdateReqDto.category());
+        PersonalDashboardInfoResDto response = PersonalDashboardInfoResDto.from(personalDashboard);
+        given(personalDashboardService.update(anyString(), anyLong(),
+                any(PersonalDashboardUpdateReqDto.class))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(patch("/api/dashboards/{dashboardId}", 1L)
+                        .header("Authorization", "Bearer valid-token")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(personalDashboardUpdateReqDto)))
+                .andDo(print())
+                .andDo(document("dashboard/save",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("dashboardId").description("대시보드 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").description("개인 대시보드 제목"),
+                                fieldWithPath("description").description("개인 대시보드 설명"),
+                                fieldWithPath("isPublic").description("개인 대시보드 공개 범위"),
+                                fieldWithPath("category").description("개인 대시보드 카테고리")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.title").description("개인 대시보드 제목"),
+                                fieldWithPath("data.description").description("개인 대시보드 설명"),
+                                fieldWithPath("data.isPublic").description("개인 대시보드 공개 범위"),
+                                fieldWithPath("data.category").description("개인 대시보드 카테고리")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardControllerTest.java
@@ -4,11 +4,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -134,7 +136,7 @@ class PersonalDashboardControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(personalDashboardUpdateReqDto)))
                 .andDo(print())
-                .andDo(document("dashboard/save",
+                .andDo(document("dashboard/update",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(
@@ -160,4 +162,29 @@ class PersonalDashboardControllerTest extends ControllerTest {
                 ))
                 .andExpect(status().isOk());
     }
+
+    @DisplayName("DELETE 개인 대시보드를 논리적으로 삭제합니다.")
+    @Test
+    void 개인_대시보드_삭제() throws Exception {
+        // given
+        doNothing().when(personalDashboardService).delete(anyString(), anyLong());
+
+        // when & then
+        mockMvc.perform(delete("/api/dashboards/{dashboardId}", 1L)
+                        .header("Authorization", "Bearer valid-token")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("dashboard/delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("dashboardId").description("개인 대시보드 ID")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+    
 }

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardControllerTest.java
@@ -259,7 +259,8 @@ class PersonalDashboardControllerTest extends ControllerTest {
                                 fieldWithPath("data.title").description("개인 대시보드 제목"),
                                 fieldWithPath("data.description").description("개인 대시보드 설명"),
                                 fieldWithPath("data.isPublic").description("개인 대시보드 공개 범위"),
-                                fieldWithPath("data.category").description("개인 대시보드 카테고리")
+                                fieldWithPath("data.category").description("개인 대시보드 카테고리"),
+                                fieldWithPath("data.blockProgress").description("개인 대시보드의 완료된 블록 진행률")
                         )
                 ))
                 .andExpect(status().isOk());

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardServiceTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardServiceTest.java
@@ -1,0 +1,137 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.personal.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request.PersonalDashboardSaveReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request.PersonalDashboardUpdateReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.response.PersonalDashboardInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.repository.PersonalDashboardRepository;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.exception.DashboardAccessDeniedException;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.domain.SocialType;
+import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PersonalDashboardServiceTest {
+
+    @Mock
+    private PersonalDashboardRepository personalDashboardRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private PersonalDashboardService personalDashboardService;
+
+    private Member member;
+    private PersonalDashboard personalDashboard;
+    private PersonalDashboardSaveReqDto personalDashboardSaveReqDto;
+    private PersonalDashboardUpdateReqDto personalDashboardUpdateReqDto;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .email("email")
+                .name("name")
+                .nickname("nickname")
+                .socialType(SocialType.GOOGLE)
+                .introduction("introduction")
+                .picture("picture")
+                .build();
+
+        when(memberRepository.findByEmail(anyString())).thenReturn(Optional.ofNullable(member));
+
+        personalDashboardSaveReqDto = new PersonalDashboardSaveReqDto("title", "description", false, "category");
+        personalDashboardUpdateReqDto = new PersonalDashboardUpdateReqDto("updateTitle", "updateDescription",
+                "updateCategory");
+        personalDashboard = PersonalDashboard.builder()
+                .title(personalDashboardSaveReqDto.title())
+                .description(personalDashboardSaveReqDto.description())
+                .isPublic(personalDashboardSaveReqDto.isPublic())
+                .category(personalDashboardSaveReqDto.category())
+                .member(member)
+                .build();
+    }
+
+    @DisplayName("개인 대시보드를 저장합니다.")
+    @Test
+    void 개인_대시보드_저장() {
+        // given
+        when(personalDashboardRepository.save(any(PersonalDashboard.class))).thenReturn(personalDashboard);
+
+        // when
+        PersonalDashboardInfoResDto result = personalDashboardService.save(
+                member.getEmail(),
+                personalDashboardSaveReqDto);
+
+        // then
+        assertAll(() -> {
+            assertThat(result.title()).isEqualTo("title");
+            assertThat(result.description()).isEqualTo("description");
+            assertThat(result.isPublic()).isEqualTo(false);
+            assertThat(result.category()).isEqualTo("category");
+        });
+    }
+
+    @DisplayName("개인 대시보드를 수정합니다.")
+    @Test
+    void 개인_대시보드_수정() {
+        // given
+        Long dashboardId = 1L;
+        when(personalDashboardRepository.findById(dashboardId)).thenReturn(Optional.of(personalDashboard));
+
+        // when
+        PersonalDashboardInfoResDto result = personalDashboardService.update(
+                member.getEmail(),
+                dashboardId,
+                personalDashboardUpdateReqDto);
+
+        // then
+        assertAll(() -> {
+            assertThat(result.title()).isEqualTo("updateTitle");
+            assertThat(result.description()).isEqualTo("updateDescription");
+            assertThat(result.isPublic()).isEqualTo(false);
+            assertThat(result.category()).isEqualTo("updateCategory");
+        });
+    }
+
+    @DisplayName("생성자가 아닌 사용자가 개인 대시보드를 수정하는데 실패합니다. (DashboardAccessDeniedException 발생)")
+    @Test
+    void 개인_대시보드_수정_실패() {
+        // given
+        Long dashboardId = 1L;
+        String unauthorizedEmail = "unauthorizedEmail@email.com";
+
+        Member unauthorizedMember = Member.builder()
+                .email(unauthorizedEmail)
+                .name("name")
+                .nickname("nickname")
+                .socialType(SocialType.GOOGLE)
+                .introduction("introduction")
+                .picture("picture")
+                .build();
+
+        when(memberRepository.findByEmail(unauthorizedEmail)).thenReturn(Optional.of(unauthorizedMember));
+        when(personalDashboardRepository.findById(dashboardId)).thenReturn(Optional.of(personalDashboard));
+
+        // when & then
+        assertThatThrownBy(
+                () -> personalDashboardService.update(unauthorizedEmail, dashboardId, personalDashboardUpdateReqDto))
+                .isInstanceOf(DashboardAccessDeniedException.class);
+    }
+
+}

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardServiceTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardServiceTest.java
@@ -56,7 +56,10 @@ class PersonalDashboardServiceTest {
         when(memberRepository.findByEmail(anyString())).thenReturn(Optional.ofNullable(member));
 
         personalDashboardSaveReqDto = new PersonalDashboardSaveReqDto("title", "description", false, "category");
-        personalDashboardUpdateReqDto = new PersonalDashboardUpdateReqDto("updateTitle", "updateDescription",
+        personalDashboardUpdateReqDto = new PersonalDashboardUpdateReqDto(
+                "updateTitle",
+                "updateDescription",
+                true,
                 "updateCategory");
         personalDashboard = PersonalDashboard.builder()
                 .title(personalDashboardSaveReqDto.title())
@@ -104,7 +107,7 @@ class PersonalDashboardServiceTest {
         assertAll(() -> {
             assertThat(result.title()).isEqualTo("updateTitle");
             assertThat(result.description()).isEqualTo("updateDescription");
-            assertThat(result.isPublic()).isEqualTo(false);
+            assertThat(result.isPublic()).isEqualTo(true);
             assertThat(result.category()).isEqualTo("updateCategory");
         });
     }
@@ -130,8 +133,8 @@ class PersonalDashboardServiceTest {
 
         // when & then
         assertThatThrownBy(
-                () -> personalDashboardService.update(unauthorizedEmail, dashboardId, personalDashboardUpdateReqDto))
-                .isInstanceOf(DashboardAccessDeniedException.class);
+                () -> personalDashboardService.update(unauthorizedEmail, dashboardId, personalDashboardUpdateReqDto)
+        ).isInstanceOf(DashboardAccessDeniedException.class);
     }
 
 }

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardServiceTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,9 +16,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request.PersonalDashboardSaveReqDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request.PersonalDashboardUpdateReqDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.response.PersonalDashboardInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.response.PersonalDashboardListResDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.repository.PersonalDashboardRepository;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.exception.DashboardAccessDeniedException;
@@ -162,6 +168,47 @@ class PersonalDashboardServiceTest {
         // then
         assertAll(() -> {
             assertThat(personalDashboard.getStatus()).isEqualTo(Status.DELETED);
+        });
+    }
+
+    @DisplayName("개인 대시보드를 전체 조회합니다.")
+    @Test
+    void 개인_대시보드_전체_조회() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<PersonalDashboard> personalDashboardPage = new PageImpl<>(
+                List.of(personalDashboard),
+                pageable,
+                1);
+
+        when(personalDashboardRepository.findForPersonalDashboard(any(Member.class), any(Pageable.class)))
+                .thenReturn(personalDashboardPage);
+
+        // when
+        PersonalDashboardListResDto result = personalDashboardService.
+                findForPersonalDashboard(member.getEmail(), pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.personalDashboardListResDto()).hasSize(1);
+    }
+
+    @DisplayName("개인 대시보드를 상세 봅니다.")
+    @Test
+    void 개인_대시보드_상세보기() {
+        // given
+        Long dashboardId = 1L;
+        when(personalDashboardRepository.findById(dashboardId)).thenReturn(Optional.of(personalDashboard));
+
+        // when
+        PersonalDashboardInfoResDto result = personalDashboardService.findById(member.getEmail(), dashboardId);
+
+        // then
+        assertAll(() -> {
+            assertThat(result.title()).isEqualTo("title");
+            assertThat(result.description()).isEqualTo("description");
+            assertThat(result.isPublic()).isEqualTo(false);
+            assertThat(result.category()).isEqualTo("category");
         });
     }
 

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardServiceTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardServiceTest.java
@@ -209,6 +209,7 @@ class PersonalDashboardServiceTest {
             assertThat(result.description()).isEqualTo("description");
             assertThat(result.isPublic()).isEqualTo(false);
             assertThat(result.category()).isEqualTo("category");
+            assertThat(result.blockProgress()).isEqualTo(0.0);
         });
     }
 

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/domain/PersonalDashboardTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/domain/PersonalDashboardTest.java
@@ -1,0 +1,65 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
+
+class PersonalDashboardTest {
+
+    private PersonalDashboard personalDashboard;
+
+    @BeforeEach
+    void setUp() {
+        personalDashboard = PersonalDashboard.builder()
+                .title("title")
+                .description("description")
+                .isPublic(false)
+                .category("category")
+                .build();
+    }
+
+    @DisplayName("개인 대시보드의 모든 값을 수정합니다.")
+    @Test
+    void 개인_대시보드_수정() {
+        // given
+        String updateTitle = "updateTitle";
+        String updateDescription = "updateDescription";
+        boolean updateIsPublic = true;
+        String updateCategory = "category";
+
+        // when
+        personalDashboard.update(updateTitle, updateDescription, updateIsPublic, updateCategory);
+
+        // then
+        assertAll(() -> {
+            assertThat(personalDashboard.getTitle()).isEqualTo(updateTitle);
+            assertThat(personalDashboard.getDescription()).isEqualTo(updateDescription);
+            assertThat(personalDashboard.isPublic()).isEqualTo(updateIsPublic);
+            assertThat(personalDashboard.getCategory()).isEqualTo(updateCategory);
+        });
+    }
+
+    @DisplayName("개인 대시보드 논리 삭제 상태를 수정합니다.")
+    @Test
+    void 개인_대시보드_상태_수정() {
+        // given
+        assertThat(personalDashboard.getStatus()).isEqualTo(Status.ACTIVE);
+
+        // when
+        personalDashboard.statusUpdate();
+
+        // then
+        assertThat(personalDashboard.getStatus()).isEqualTo(Status.DELETED);
+
+        // when
+        personalDashboard.statusUpdate();
+
+        // then
+        assertThat(personalDashboard.getStatus()).isEqualTo(Status.ACTIVE);
+    }
+
+}

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/domain/repository/PersonalDashboardRepositoryTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/domain/repository/PersonalDashboardRepositoryTest.java
@@ -1,0 +1,124 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
+import shop.kkeujeok.kkeujeokbackend.block.domain.repository.BlockRepository;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
+import shop.kkeujeok.kkeujeokbackend.global.config.JpaAuditingConfig;
+import shop.kkeujeok.kkeujeokbackend.global.config.QuerydslConfig;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.domain.SocialType;
+import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
+
+@DataJpaTest
+@Import({JpaAuditingConfig.class, QuerydslConfig.class})
+@ActiveProfiles("test")
+class PersonalDashboardRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BlockRepository blockRepository;
+
+    @Autowired
+    private PersonalDashboardRepository personalDashboardRepository;
+
+    private Member member;
+    private PersonalDashboard personalDashboard;
+    private Block block1;
+    private Block block2;
+    private Block block3;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .email("email")
+                .name("name")
+                .nickname("nickname")
+                .socialType(SocialType.GOOGLE)
+                .introduction("introduction")
+                .picture("picture")
+                .build();
+
+        memberRepository.save(member);
+
+        personalDashboard = PersonalDashboard.builder()
+                .member(member)
+                .title("title")
+                .description("description")
+                .isPublic(false)
+                .category("category")
+                .build();
+
+        personalDashboardRepository.save(personalDashboard);
+
+        block1 = Block.builder()
+                .title("title1")
+                .contents("contents1")
+                .progress(Progress.COMPLETED)
+                .deadLine("2024.07.27 11:03")
+                .dashboard(personalDashboard)
+                .build();
+
+        block2 = Block.builder()
+                .title("title2")
+                .contents("contents2")
+                .progress(Progress.NOT_STARTED)
+                .deadLine("2024.07.27 11:04")
+                .dashboard(personalDashboard)
+                .build();
+
+        block3 = Block.builder()
+                .title("title3")
+                .contents("contents3")
+                .progress(Progress.COMPLETED)
+                .deadLine("2024.07.27 11:05")
+                .dashboard(personalDashboard)
+                .build();
+
+        blockRepository.save(block1);
+        blockRepository.save(block2);
+        blockRepository.save(block3);
+    }
+
+    @DisplayName("개인 대시보드를 전체 조회합니다.")
+    @Test
+    void 개인_대시보드_전체_조회() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<PersonalDashboard> result = personalDashboardRepository.findForPersonalDashboard(member, pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("title");
+        assertThat(result.getContent().get(0).getMember()).isEqualTo(member);
+    }
+
+    @DisplayName("대시보드의 완료된 블록 비율을 계산합니다.")
+    @Test
+    void 개인_대시보드_완료_블록_비율_계산() {
+        // when
+        double completionPercentage = personalDashboardRepository
+                .calculateCompletionPercentage(personalDashboard.getId());
+
+        // then
+        assertThat(completionPercentage).isEqualTo(66.67, offset(0.01));
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #62 

## 📝작업 내용

> Dashboard를 상속하는 personalDashboard 도메인을 구현했습니다.
개인 대시보드 저장, 수정 기능을 구현하고, Block과 연관 관계를 추가하여 Block 저장시에 dashboardId값을 추가할 예정입니다.