### PR TITLE
Feat(#67 #62): 팀 대시보드 기능 구현, 테스트 코드 구현, 개인 대시보드 삭제 메시지, queryDSL 수정

### DIFF
--- a/src/docs/asciidoc/teamDashboard.adoc
+++ b/src/docs/asciidoc/teamDashboard.adoc
@@ -1,0 +1,93 @@
+== 팀 대시보드 API 문서
+
+=== 팀 대시보드 생성 API
+
+==== 요청
+
+include::{snippets}/dashboard/team/save/http-request.adoc[]
+include::{snippets}/dashboard/team/save/request-fields.adoc[]
+
+==== 응답
+
+include::{snippets}/dashboard/team/save/http-response.adoc[]
+include::{snippets}/dashboard/team/save/response-fields.adoc[]
+
+=== 팀 대시보드 수정 API
+
+==== 요청
+
+include::{snippets}/dashboard/team/update/http-request.adoc[]
+include::{snippets}/dashboard/team/update/path-parameters.adoc[]
+include::{snippets}/dashboard/team/update/request-fields.adoc[]
+
+==== 응답
+
+include::{snippets}/dashboard/team/update/http-response.adoc[]
+include::{snippets}/dashboard/team/update/response-fields.adoc[]
+
+=== 팀 대시보드 전체 조회
+
+==== 요청
+
+include::{snippets}/dashboard/team/findForTeamDashboard/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/dashboard/team/findForTeamDashboard/http-response.adoc[]
+include::{snippets}/dashboard/team/findForTeamDashboard/response-fields.adoc[]
+
+=== 팀 대시보드 상세 조회
+
+==== 요청
+
+include::{snippets}/dashboard/team/findById/http-request.adoc[]
+include::{snippets}/dashboard/team/findById/path-parameters.adoc[]
+
+==== 응답
+
+include::{snippets}/dashboard/team/findById/http-response.adoc[]
+include::{snippets}/dashboard/team/findById/response-fields.adoc[]
+
+=== 팀 대시보드 삭제
+
+==== 요청
+
+include::{snippets}/dashboard/team/delete/http-request.adoc[]
+include::{snippets}/dashboard/team/delete/path-parameters.adoc[]
+
+==== 응답
+
+include::{snippets}/dashboard/team/delete/http-response.adoc[]
+
+=== 팀 대시보드 초대 멤버 리스트 조회
+
+==== 요청
+
+include::{snippets}/dashboard/team/search/http-request.adoc[]
+include::{snippets}/dashboard/team/search/query-parameters.adoc[]
+
+==== 응답
+
+include::{snippets}/dashboard/team/search/http-response.adoc[]
+
+=== 팀 대시보드 참여 초대 수락
+
+==== 요청
+
+include::{snippets}/dashboard/team/join/http-request.adoc[]
+include::{snippets}/dashboard/team/join/path-parameters.adoc[]
+
+==== 응답
+
+include::{snippets}/dashboard/team/join/http-response.adoc[]
+
+=== 팀 대시보드 탈퇴
+
+==== 요청
+
+include::{snippets}/dashboard/team/leave/http-request.adoc[]
+include::{snippets}/dashboard/team/leave/path-parameters.adoc[]
+
+==== 응답
+
+include::{snippets}/dashboard/team/leave/http-response.adoc[]

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepository.java
@@ -3,12 +3,15 @@ package shop.kkeujeok.kkeujeokbackend.dashboard.domain.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.TeamDashboard;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
 public interface DashboardCustomRepository {
 
     Page<PersonalDashboard> findForPersonalDashboard(Member member, Pageable pageable);
 
+    Page<TeamDashboard> findForTeamDashboard(Member member, Pageable pageable);
+
     double calculateCompletionPercentage(Long dashboardId);
-    
+
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepository.java
@@ -1,5 +1,6 @@
 package shop.kkeujeok.kkeujeokbackend.dashboard.domain.repository;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
@@ -11,6 +12,8 @@ public interface DashboardCustomRepository {
     Page<PersonalDashboard> findForPersonalDashboard(Member member, Pageable pageable);
 
     Page<TeamDashboard> findForTeamDashboard(Member member, Pageable pageable);
+
+    List<Member> findForMembersByQuery(String query);
 
     double calculateCompletionPercentage(Long dashboardId);
 

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepositoryImpl.java
@@ -2,6 +2,7 @@ package shop.kkeujeok.kkeujeokbackend.dashboard.domain.repository;
 
 import static shop.kkeujeok.kkeujeokbackend.block.domain.QBlock.block;
 import static shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.QPersonalDashboard.personalDashboard;
+import static shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.QTeamDashboard.teamDashboard;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.TeamDashboard;
 import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
@@ -45,6 +47,26 @@ public class DashboardCustomRepositoryImpl implements DashboardCustomRepository 
         return new PageImpl<>(dashboards, pageable, total);
     }
 
+    @Override
+    public Page<TeamDashboard> findForTeamDashboard(Member member, Pageable pageable) {
+        long total = queryFactory
+                .selectFrom(teamDashboard)
+                .where(teamDashboard._super.member.eq(member))
+                .stream()
+                .count();
+
+        List<TeamDashboard> dashboards = queryFactory
+                .selectFrom(teamDashboard)
+                .where(teamDashboard._super.member.eq(member)
+                        .and(teamDashboard._super.status.eq(Status.ACTIVE)))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return new PageImpl<>(dashboards, pageable, total);
+    }
+
+    @Override
     public double calculateCompletionPercentage(Long dashboardId) {
         List<Block> blocks = queryFactory
                 .selectFrom(block)

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepositoryImpl.java
@@ -3,9 +3,12 @@ package shop.kkeujeok.kkeujeokbackend.dashboard.domain.repository;
 import static shop.kkeujeok.kkeujeokbackend.block.domain.QBlock.block;
 import static shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.QPersonalDashboard.personalDashboard;
 import static shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.QTeamDashboard.teamDashboard;
+import static shop.kkeujeok.kkeujeokbackend.member.domain.QMember.member;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +25,7 @@ import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 @Transactional(readOnly = true)
 public class DashboardCustomRepositoryImpl implements DashboardCustomRepository {
 
+    private static final Logger log = LoggerFactory.getLogger(DashboardCustomRepositoryImpl.class);
     private final JPAQueryFactory queryFactory;
 
     public DashboardCustomRepositoryImpl(JPAQueryFactory queryFactory) {
@@ -64,6 +68,26 @@ public class DashboardCustomRepositoryImpl implements DashboardCustomRepository 
                 .fetch();
 
         return new PageImpl<>(dashboards, pageable, total);
+    }
+
+    @Override
+    public List<Member> findForMembersByQuery(String query) {
+        if (query.contains("#")) {
+            String[] parts = query.split("#");
+            String nickname = parts[0];
+            String tag = "#" + parts[1];
+
+            return queryFactory
+                    .selectFrom(member)
+                    .where(member.nickname.eq(nickname)
+                            .and(member.tag.eq(tag)))
+                    .fetch();
+        }
+        
+        return queryFactory
+                .selectFrom(member)
+                .where(member.email.eq(query))
+                .fetch();
     }
 
     @Override

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/domain/repository/DashboardCustomRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
+import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
 @Repository
@@ -35,7 +36,8 @@ public class DashboardCustomRepositoryImpl implements DashboardCustomRepository 
 
         List<PersonalDashboard> dashboards = queryFactory
                 .selectFrom(personalDashboard)
-                .where(personalDashboard._super.member.eq(member))
+                .where(personalDashboard._super.member.eq(member)
+                        .and(personalDashboard._super.status.eq(Status.ACTIVE)))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardController.java
@@ -64,7 +64,7 @@ public class PersonalDashboardController {
     public RspTemplate<Void> delete(@CurrentUserEmail String email,
                                     @PathVariable(name = "dashboardId") Long dashboardId) {
         personalDashboardService.delete(email, dashboardId);
-        return new RspTemplate<>(HttpStatus.OK, "개인 대시보드 삭제");
+        return new RspTemplate<>(HttpStatus.OK, "개인 대시보드 삭제, 복구");
     }
 
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/response/PersonalDashboardListResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/dto/response/PersonalDashboardListResDto.java
@@ -9,8 +9,8 @@ public record PersonalDashboardListResDto(
         List<PersonalDashboardInfoResDto> personalDashboardListResDto,
         PageInfoResDto pageInfoResDto
 ) {
-    public static PersonalDashboardListResDto from(List<PersonalDashboardInfoResDto> personalDashboards,
-                                                   PageInfoResDto pageInfoResDto) {
+    public static PersonalDashboardListResDto of(List<PersonalDashboardInfoResDto> personalDashboards,
+                                                 PageInfoResDto pageInfoResDto) {
         return PersonalDashboardListResDto.builder()
                 .personalDashboardListResDto(personalDashboards)
                 .pageInfoResDto(pageInfoResDto)

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
@@ -68,7 +68,7 @@ public class PersonalDashboardService {
                 .toList();
 
         return PersonalDashboardListResDto
-                .from(personalDashboardInfoResDtoList, PageInfoResDto.from(personalDashboards));
+                .of(personalDashboardInfoResDtoList, PageInfoResDto.from(personalDashboards));
     }
 
     // 개인 대시보드 상세조회

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
@@ -89,6 +89,8 @@ public class PersonalDashboardService {
         PersonalDashboard dashboard = personalDashboardRepository.findById(dashboardId)
                 .orElseThrow(DashboardNotFoundException::new);
 
+        verifyMemberIsAuthor(dashboard, member);
+
         dashboard.statusUpdate();
     }
 

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardController.java
@@ -38,7 +38,7 @@ public class TeamDashboardController {
 
     @PatchMapping("/{dashboardId}")
     public RspTemplate<TeamDashboardInfoResDto> update(@CurrentUserEmail String email,
-                                                       @PathVariable Long dashboardId,
+                                                       @PathVariable(name = "dashboardId") Long dashboardId,
                                                        @RequestBody @Valid TeamDashboardUpdateReqDto teamDashboardUpdateReqDto) {
         return new RspTemplate<>(HttpStatus.OK,
                 "팀 대시보드 수정",
@@ -62,9 +62,23 @@ public class TeamDashboardController {
 
     @DeleteMapping("/{dashboardId}")
     public RspTemplate<Void> delete(@CurrentUserEmail String email,
-                                    @PathVariable Long dashboardId) {
+                                    @PathVariable(name = "dashboardId") Long dashboardId) {
         teamDashboardService.delete(email, dashboardId);
         return new RspTemplate<>(HttpStatus.OK, "팀 대시보드 삭제, 복구");
     }
 
+    @PostMapping("/{dashboardId}/join")
+    public RspTemplate<Void> joinTeam(@CurrentUserEmail String email,
+                                      @PathVariable(name = "dashboardId") Long dashboardId) {
+        teamDashboardService.joinTeam(email, dashboardId);
+        return new RspTemplate<>(HttpStatus.OK, "팀 가입");
+    }
+
+    @PostMapping("/{dashboardId}/leave")
+    public RspTemplate<Void> leaveTeam(@CurrentUserEmail String email,
+                                       @PathVariable(name = "dashboardId") Long dashboardId) {
+        teamDashboardService.leaveTeam(email, dashboardId);
+        return new RspTemplate<>(HttpStatus.OK, "팀 탈퇴");
+    }
+    
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardController.java
@@ -1,0 +1,31 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.team.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardSaveReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboardInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.application.TeamDashboardService;
+import shop.kkeujeok.kkeujeokbackend.global.annotation.CurrentUserEmail;
+import shop.kkeujeok.kkeujeokbackend.global.template.RspTemplate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/dashboards/team")
+public class TeamDashboardController {
+
+    private final TeamDashboardService teamDashboardService;
+
+    @PostMapping("/")
+    public RspTemplate<TeamDashboardInfoResDto> save(@CurrentUserEmail String email,
+                                                     @RequestBody @Valid TeamDashboardSaveReqDto teamDashboardSaveReqDto) {
+        return new RspTemplate<>(HttpStatus.OK,
+                "팀 대시보드 생성",
+                teamDashboardService.save(email, teamDashboardSaveReqDto));
+    }
+
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardController.java
@@ -3,6 +3,7 @@ package shop.kkeujeok.kkeujeokbackend.dashboard.team.api;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,6 +39,13 @@ public class TeamDashboardController {
         return new RspTemplate<>(HttpStatus.OK,
                 "팀 대시보드 수정",
                 teamDashboardService.update(email, dashboardId, teamDashboardUpdateReqDto));
+    }
+
+    @DeleteMapping("/{dashboardId}")
+    public RspTemplate<Void> delete(@CurrentUserEmail String email,
+                                    @PathVariable Long dashboardId) {
+        teamDashboardService.delete(email, dashboardId);
+        return new RspTemplate<>(HttpStatus.OK, "팀 대시보드 삭제, 복구");
     }
 
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardController.java
@@ -2,17 +2,21 @@ package shop.kkeujeok.kkeujeokbackend.dashboard.team.api;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardSaveReqDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardUpdateReqDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboardInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboardListResDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.application.TeamDashboardService;
 import shop.kkeujeok.kkeujeokbackend.global.annotation.CurrentUserEmail;
 import shop.kkeujeok.kkeujeokbackend.global.template.RspTemplate;
@@ -39,6 +43,21 @@ public class TeamDashboardController {
         return new RspTemplate<>(HttpStatus.OK,
                 "팀 대시보드 수정",
                 teamDashboardService.update(email, dashboardId, teamDashboardUpdateReqDto));
+    }
+
+    @GetMapping("/")
+    public RspTemplate<TeamDashboardListResDto> findForTeamDashboard(@CurrentUserEmail String email,
+                                                                     @RequestParam(name = "page", defaultValue = "0") int page,
+                                                                     @RequestParam(name = "size", defaultValue = "10") int size) {
+        return new RspTemplate<>(HttpStatus.OK,
+                "팀 대시보드 전체 조회",
+                teamDashboardService.findForTeamDashboard(email, PageRequest.of(page, size)));
+    }
+
+    @GetMapping("/{dashboardId}")
+    public RspTemplate<TeamDashboardInfoResDto> findById(@CurrentUserEmail String email,
+                                                         @PathVariable(name = "dashboardId") Long dashboardId) {
+        return new RspTemplate<>(HttpStatus.OK, "팀 대시보드 상세보기", teamDashboardService.findById(email, dashboardId));
     }
 
     @DeleteMapping("/{dashboardId}")

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardController.java
@@ -3,11 +3,14 @@ package shop.kkeujeok.kkeujeokbackend.dashboard.team.api;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardSaveReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardUpdateReqDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboardInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.application.TeamDashboardService;
 import shop.kkeujeok.kkeujeokbackend.global.annotation.CurrentUserEmail;
@@ -26,6 +29,15 @@ public class TeamDashboardController {
         return new RspTemplate<>(HttpStatus.OK,
                 "팀 대시보드 생성",
                 teamDashboardService.save(email, teamDashboardSaveReqDto));
+    }
+
+    @PatchMapping("/{dashboardId}")
+    public RspTemplate<TeamDashboardInfoResDto> update(@CurrentUserEmail String email,
+                                                       @PathVariable Long dashboardId,
+                                                       @RequestBody @Valid TeamDashboardUpdateReqDto teamDashboardUpdateReqDto) {
+        return new RspTemplate<>(HttpStatus.OK,
+                "팀 대시보드 수정",
+                teamDashboardService.update(email, dashboardId, teamDashboardUpdateReqDto));
     }
 
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardSaveReqDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardUpdateReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.SearchMemberListResDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboardInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboardListResDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.application.TeamDashboardService;
@@ -80,5 +81,10 @@ public class TeamDashboardController {
         teamDashboardService.leaveTeam(email, dashboardId);
         return new RspTemplate<>(HttpStatus.OK, "팀 탈퇴");
     }
-    
+
+    @GetMapping("/search")
+    public RspTemplate<SearchMemberListResDto> search(@RequestParam(name = "query") String query) {
+        return new RspTemplate<>(HttpStatus.OK, "팀원 초대 리스트", teamDashboardService.searchMembers(query));
+    }
+
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/request/TeamDashboardSaveReqDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/request/TeamDashboardSaveReqDto.java
@@ -1,0 +1,23 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.TeamDashboard;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+public record TeamDashboardSaveReqDto(
+        @NotBlank(message = "필수 입력값 입니다.")
+        String title,
+
+        @NotBlank(message = "필수 입력값 입니다.")
+        @Size(max = 300)
+        String description
+) {
+    public TeamDashboard toEntity(Member member) {
+        return TeamDashboard.builder()
+                .title(title)
+                .description(description)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/request/TeamDashboardUpdateReqDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/request/TeamDashboardUpdateReqDto.java
@@ -1,0 +1,7 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request;
+
+public record TeamDashboardUpdateReqDto(
+        String title,
+        String description
+) {
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/response/SearchMemberListResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/response/SearchMemberListResDto.java
@@ -1,0 +1,34 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+@Builder
+public record SearchMemberListResDto(
+        List<SearchMemberInfoResDto> searchMembers
+) {
+    public static SearchMemberListResDto from(List<Member> members) {
+        return SearchMemberListResDto.builder()
+                .searchMembers(members.stream()
+                        .map(SearchMemberInfoResDto::from)
+                        .toList())
+                .build();
+    }
+
+    @Builder
+    private record SearchMemberInfoResDto(
+            Long id,
+            String picture,
+            String email
+    ) {
+        private static SearchMemberInfoResDto from(Member member) {
+            return SearchMemberInfoResDto.builder()
+                    .id(member.getId())
+                    .picture(member.getPicture())
+                    .email(member.getEmail())
+                    .build();
+        }
+    }
+
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/response/TeamDashboardInfoResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/response/TeamDashboardInfoResDto.java
@@ -14,12 +14,22 @@ public record TeamDashboardInfoResDto(
         double blockProgress
 ) {
     public static TeamDashboardInfoResDto of(Member member, TeamDashboard dashboard) {
+        return commonBuilder(member, dashboard)
+                .build();
+    }
+
+    public static TeamDashboardInfoResDto detailOf(Member member, TeamDashboard dashboard, double blockProgress) {
+        return commonBuilder(member, dashboard)
+                .blockProgress(blockProgress)
+                .build();
+    }
+
+    public static TeamDashboardInfoResDtoBuilder commonBuilder(Member member, TeamDashboard dashboard) {
         return TeamDashboardInfoResDto.builder()
                 .dashboardId(dashboard.getId())
                 .myId(member.getId())
                 .creatorId(dashboard.getMember().getId())
                 .title(dashboard.getTitle())
-                .description(dashboard.getDescription())
-                .build();
+                .description(dashboard.getDescription());
     }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/response/TeamDashboardInfoResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/response/TeamDashboardInfoResDto.java
@@ -1,8 +1,10 @@
 package shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response;
 
+import java.util.List;
 import lombok.Builder;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.TeamDashboard;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.domain.SocialType;
 
 @Builder
 public record TeamDashboardInfoResDto(
@@ -11,7 +13,8 @@ public record TeamDashboardInfoResDto(
         Long creatorId,
         String title,
         String description,
-        double blockProgress
+        double blockProgress,
+        List<JoinMemberInfoResDto> joinMembers
 ) {
     public static TeamDashboardInfoResDto of(Member member, TeamDashboard dashboard) {
         return commonBuilder(member, dashboard)
@@ -21,6 +24,11 @@ public record TeamDashboardInfoResDto(
     public static TeamDashboardInfoResDto detailOf(Member member, TeamDashboard dashboard, double blockProgress) {
         return commonBuilder(member, dashboard)
                 .blockProgress(blockProgress)
+                .joinMembers(dashboard.getTeamDashboardMemberMappings().stream()
+                        .map(teamDashboardMemberMapping -> {
+                            return JoinMemberInfoResDto.from(teamDashboardMemberMapping.getMember());
+                        })
+                        .toList())
                 .build();
     }
 
@@ -32,4 +40,26 @@ public record TeamDashboardInfoResDto(
                 .title(dashboard.getTitle())
                 .description(dashboard.getDescription());
     }
+
+    @Builder
+    private record JoinMemberInfoResDto(
+            String picture,
+            String email,
+            String name,
+            String nickName,
+            SocialType socialType,
+            String introduction
+    ) {
+        private static JoinMemberInfoResDto from(Member member) {
+            return JoinMemberInfoResDto.builder()
+                    .picture(member.getPicture())
+                    .email(member.getEmail())
+                    .name(member.getName())
+                    .nickName(member.getNickname())
+                    .socialType(member.getSocialType())
+                    .introduction(member.getIntroduction())
+                    .build();
+        }
+    }
+
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/response/TeamDashboardInfoResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/response/TeamDashboardInfoResDto.java
@@ -1,0 +1,25 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response;
+
+import lombok.Builder;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.TeamDashboard;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+@Builder
+public record TeamDashboardInfoResDto(
+        Long dashboardId,
+        Long myId,
+        Long creatorId,
+        String title,
+        String description,
+        double blockProgress
+) {
+    public static TeamDashboardInfoResDto of(Member member, TeamDashboard dashboard) {
+        return TeamDashboardInfoResDto.builder()
+                .dashboardId(dashboard.getId())
+                .myId(member.getId())
+                .creatorId(dashboard.getMember().getId())
+                .title(dashboard.getTitle())
+                .description(dashboard.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/response/TeamDashboardListResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/response/TeamDashboardListResDto.java
@@ -1,0 +1,19 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import shop.kkeujeok.kkeujeokbackend.global.dto.PageInfoResDto;
+
+@Builder
+public record TeamDashboardListResDto(
+        List<TeamDashboardInfoResDto> teamDashboardInfoResDto,
+        PageInfoResDto pageInfoResDto
+) {
+    public static TeamDashboardListResDto of(List<TeamDashboardInfoResDto> teamDashboards,
+                                             PageInfoResDto pageInfoResDto) {
+        return TeamDashboardListResDto.builder()
+                .teamDashboardInfoResDto(teamDashboards)
+                .pageInfoResDto(pageInfoResDto)
+                .build();
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardService.java
@@ -1,0 +1,33 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.team.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardSaveReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboardInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.TeamDashboard;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.repository.TeamDashboardRepository;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
+import shop.kkeujeok.kkeujeokbackend.member.exception.MemberNotFoundException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamDashboardService {
+
+    private final TeamDashboardRepository teamDashboardRepository;
+    private final MemberRepository memberRepository;
+
+    // 팀 대시보드 저장
+    @Transactional
+    public TeamDashboardInfoResDto save(String email, TeamDashboardSaveReqDto teamDashboardSaveReqDto) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        TeamDashboard teamDashboard = teamDashboardSaveReqDto.toEntity(member);
+
+        teamDashboardRepository.save(teamDashboard);
+
+        return TeamDashboardInfoResDto.of(member, teamDashboard);
+    }
+
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardService.java
@@ -3,7 +3,10 @@ package shop.kkeujeok.kkeujeokbackend.dashboard.team.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import shop.kkeujeok.kkeujeokbackend.dashboard.exception.DashboardNotFoundException;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.exception.DashboardAccessDeniedException;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardSaveReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardUpdateReqDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboardInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.TeamDashboard;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.repository.TeamDashboardRepository;
@@ -30,4 +33,26 @@ public class TeamDashboardService {
         return TeamDashboardInfoResDto.of(member, teamDashboard);
     }
 
+    // 팀 대시보드 수정
+    @Transactional
+    public TeamDashboardInfoResDto update(String email,
+                                          Long dashboardId,
+                                          TeamDashboardUpdateReqDto teamDashboardUpdateReqDto) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        TeamDashboard dashboard = teamDashboardRepository.findById(dashboardId)
+                .orElseThrow(DashboardNotFoundException::new);
+
+        verifyMemberIsAuthor(dashboard, member);
+
+        dashboard.update(teamDashboardUpdateReqDto.title(),
+                teamDashboardUpdateReqDto.description());
+
+        return TeamDashboardInfoResDto.of(member, dashboard);
+    }
+
+    private void verifyMemberIsAuthor(TeamDashboard teamDashboard, Member member) {
+        if (!member.equals(teamDashboard.getMember())) {
+            throw new DashboardAccessDeniedException();
+        }
+    }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardService.java
@@ -57,7 +57,7 @@ public class TeamDashboardService {
 
     // 팀 대시보드 전체 조회
     public TeamDashboardListResDto findForTeamDashboard(String email, Pageable pageable) {
-        Member member = memberRepository.findByEmail("email").orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Page<TeamDashboard> teamDashboards = teamDashboardRepository.findForTeamDashboard(member, pageable);
 
         List<TeamDashboardInfoResDto> teamDashboardInfoResDtoList = teamDashboards.stream()
@@ -89,6 +89,24 @@ public class TeamDashboardService {
         verifyMemberIsAuthor(dashboard, member);
 
         dashboard.statusUpdate();
+    }
+
+    @Transactional
+    public void joinTeam(String email, Long dashboardId) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        TeamDashboard dashboard = teamDashboardRepository.findById(dashboardId)
+                .orElseThrow(DashboardNotFoundException::new);
+
+        dashboard.addMember(member);
+    }
+
+    @Transactional
+    public void leaveTeam(String email, Long dashboardId) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        TeamDashboard dashboard = teamDashboardRepository.findById(dashboardId)
+                .orElseThrow(DashboardNotFoundException::new);
+
+        dashboard.removeMember(member);
     }
 
     private void verifyMemberIsAuthor(TeamDashboard teamDashboard, Member member) {

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardService.java
@@ -50,6 +50,18 @@ public class TeamDashboardService {
         return TeamDashboardInfoResDto.of(member, dashboard);
     }
 
+    // 팀 대시보드 삭제 유무 업데이트 (논리 삭제)
+    @Transactional
+    public void delete(String email, Long dashboardId) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        TeamDashboard dashboard = teamDashboardRepository.findById(dashboardId)
+                .orElseThrow(DashboardNotFoundException::new);
+
+        verifyMemberIsAuthor(dashboard, member);
+
+        dashboard.statusUpdate();
+    }
+
     private void verifyMemberIsAuthor(TeamDashboard teamDashboard, Member member) {
         if (!member.equals(teamDashboard.getMember())) {
             throw new DashboardAccessDeniedException();

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardService.java
@@ -10,6 +10,7 @@ import shop.kkeujeok.kkeujeokbackend.dashboard.exception.DashboardNotFoundExcept
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.exception.DashboardAccessDeniedException;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardSaveReqDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardUpdateReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.SearchMemberListResDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboardInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboardListResDto;
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.TeamDashboard;
@@ -107,6 +108,12 @@ public class TeamDashboardService {
                 .orElseThrow(DashboardNotFoundException::new);
 
         dashboard.removeMember(member);
+    }
+
+    public SearchMemberListResDto searchMembers(String query) {
+        List<Member> searchMembers = teamDashboardRepository.findForMembersByQuery(query);
+
+        return SearchMemberListResDto.from(searchMembers);
     }
 
     private void verifyMemberIsAuthor(TeamDashboard teamDashboard, Member member) {

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/TeamDashboard.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/TeamDashboard.java
@@ -25,4 +25,8 @@ public class TeamDashboard extends Dashboard {
         super(title, description, member);
     }
 
+    public void update(String updateTitle, String updateDescription) {
+        super.update(updateTitle, updateDescription);
+    }
+
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/TeamDashboard.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/TeamDashboard.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import shop.kkeujeok.kkeujeokbackend.dashboard.domain.Dashboard;
+import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
 @Entity
@@ -27,6 +28,10 @@ public class TeamDashboard extends Dashboard {
 
     public void update(String updateTitle, String updateDescription) {
         super.update(updateTitle, updateDescription);
+    }
+
+    public void statusUpdate() {
+        super.statusUpdate((super.getStatus() == Status.ACTIVE) ? Status.DELETED : Status.ACTIVE);
     }
 
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/TeamDashboard.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/TeamDashboard.java
@@ -34,4 +34,15 @@ public class TeamDashboard extends Dashboard {
         super.statusUpdate((super.getStatus() == Status.ACTIVE) ? Status.DELETED : Status.ACTIVE);
     }
 
+    public void addMember(Member member) {
+        teamDashboardMemberMappings.add(TeamDashboardMemberMapping.builder()
+                .teamDashboard(this)
+                .member(member)
+                .build());
+    }
+
+    public void removeMember(Member member) {
+        teamDashboardMemberMappings.removeIf(mapping -> mapping.getMember().equals(member));
+    }
+
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/TeamDashboard.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/TeamDashboard.java
@@ -1,0 +1,28 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.team.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import shop.kkeujeok.kkeujeokbackend.dashboard.domain.Dashboard;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamDashboard extends Dashboard {
+
+    @OneToMany(mappedBy = "teamDashboard", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TeamDashboardMemberMapping> teamDashboardMemberMappings = new ArrayList<>();
+
+    @Builder
+    private TeamDashboard(String title, String description, Member member) {
+        super(title, description, member);
+    }
+
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/TeamDashboardMemberMapping.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/TeamDashboardMemberMapping.java
@@ -1,0 +1,32 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.team.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import shop.kkeujeok.kkeujeokbackend.global.entity.BaseEntity;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamDashboardMemberMapping extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_dashboard_id", nullable = false)
+    private TeamDashboard teamDashboard;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Builder
+    private TeamDashboardMemberMapping(TeamDashboard teamDashboard, Member member) {
+        this.teamDashboard = teamDashboard;
+        this.member = member;
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/repository/TeamDashboardRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/repository/TeamDashboardRepository.java
@@ -1,0 +1,8 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.kkeujeok.kkeujeokbackend.dashboard.domain.repository.DashboardCustomRepository;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.TeamDashboard;
+
+public interface TeamDashboardRepository extends JpaRepository<TeamDashboard, Long>, DashboardCustomRepository {
+}

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/common/annotation/ControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/common/annotation/ControllerTest.java
@@ -2,7 +2,6 @@ package shop.kkeujeok.kkeujeokbackend.common.annotation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -20,6 +19,7 @@ import shop.kkeujeok.kkeujeokbackend.block.application.BlockService;
 import shop.kkeujeok.kkeujeokbackend.challenge.api.ChallengeController;
 import shop.kkeujeok.kkeujeokbackend.challenge.application.ChallengeService;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.application.PersonalDashboardService;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.application.TeamDashboardService;
 import shop.kkeujeok.kkeujeokbackend.global.jwt.TokenProvider;
 import shop.kkeujeok.kkeujeokbackend.member.api.MemberControllerTest;
 import shop.kkeujeok.kkeujeokbackend.member.mypage.application.MyPageService;
@@ -47,6 +47,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected PersonalDashboardService personalDashboardService;
+
+    @MockBean
+    protected TeamDashboardService teamDashboardService;
 
     @MockBean
     protected TokenProvider tokenProvider;

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardControllerTest.java
@@ -187,7 +187,7 @@ class PersonalDashboardControllerTest extends ControllerTest {
                 List.of(personalDashboard),
                 PageRequest.of(0, 10),
                 1);
-        PersonalDashboardListResDto response = PersonalDashboardListResDto.from(
+        PersonalDashboardListResDto response = PersonalDashboardListResDto.of(
                 Collections.singletonList(PersonalDashboardInfoResDto.of(member, personalDashboard)),
                 PageInfoResDto.from(personalDashboardPage)
         );

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/api/PersonalDashboardControllerTest.java
@@ -270,7 +270,7 @@ class PersonalDashboardControllerTest extends ControllerTest {
                 .andExpect(status().isOk());
     }
 
-    @DisplayName("DELETE 개인 대시보드를 논리적으로 삭제합니다.")
+    @DisplayName("DELETE 개인 대시보드를 논리적으로 삭제하고 복구합니다.")
     @Test
     void 개인_대시보드_삭제() throws Exception {
         // given

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardServiceTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardServiceTest.java
@@ -225,7 +225,7 @@ class PersonalDashboardServiceTest {
 
         // then
         assertAll(() -> {
-            assertThat(personalDashboard.getStatus()).isEqualTo(Status.ACTIVE);
+            assertThat(deletePersonalDashboard.getStatus()).isEqualTo(Status.ACTIVE);
         });
     }
 

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardControllerTest.java
@@ -1,0 +1,377 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.team.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static shop.kkeujeok.kkeujeokbackend.global.restdocs.RestDocsHandler.requestFields;
+import static shop.kkeujeok.kkeujeokbackend.global.restdocs.RestDocsHandler.responseFields;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import shop.kkeujeok.kkeujeokbackend.auth.api.dto.request.TokenReqDto;
+import shop.kkeujeok.kkeujeokbackend.common.annotation.ControllerTest;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardSaveReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardUpdateReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.SearchMemberListResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboardInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboardListResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.TeamDashboard;
+import shop.kkeujeok.kkeujeokbackend.global.annotationresolver.CurrentUserEmailArgumentResolver;
+import shop.kkeujeok.kkeujeokbackend.global.dto.PageInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.global.error.ControllerAdvice;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.domain.SocialType;
+
+class TeamDashboardControllerTest extends ControllerTest {
+
+    private Member member;
+    private Member joinMember;
+    private TeamDashboard teamDashboard;
+    private TeamDashboardSaveReqDto teamDashboardSaveReqDto;
+    private TeamDashboardUpdateReqDto teamDashboardUpdateReqDto;
+
+    @InjectMocks
+    private TeamDashboardController teamDashboardController;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        member = Member.builder()
+                .email("email")
+                .name("name")
+                .nickname("nickname")
+                .socialType(SocialType.GOOGLE)
+                .introduction("introduction")
+                .picture("picture")
+                .build();
+
+        joinMember = Member.builder()
+                .email("joinEmail")
+                .name("joinName")
+                .nickname("joinNickname")
+                .socialType(SocialType.GOOGLE)
+                .introduction("joinIntroduction")
+                .picture("joinPicture")
+                .build();
+
+        teamDashboardSaveReqDto = new TeamDashboardSaveReqDto("title", "description");
+        teamDashboardUpdateReqDto = new TeamDashboardUpdateReqDto("updateTitle", "updateDescription");
+        teamDashboard = teamDashboardSaveReqDto.toEntity(member);
+
+        teamDashboardController = new TeamDashboardController(teamDashboardService);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(teamDashboardController)
+                .apply(documentationConfiguration(restDocumentation))
+                .setCustomArgumentResolvers(new CurrentUserEmailArgumentResolver(tokenProvider))
+                .setControllerAdvice(new ControllerAdvice())
+                .build();
+
+        when(tokenProvider.getUserEmailFromToken(any(TokenReqDto.class))).thenReturn("email");
+    }
+
+    @DisplayName("POST 팀 대시보드 저장 컨트롤러 로직 확인")
+    @Test
+    void 팀_대시보드_저장() throws Exception {
+        // given
+        TeamDashboardInfoResDto response = TeamDashboardInfoResDto.of(member, teamDashboard);
+        given(teamDashboardService.save(anyString(), any(TeamDashboardSaveReqDto.class))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/dashboards/team/")
+                        .header("Authorization", "Bearer valid-token")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(teamDashboardSaveReqDto)))
+                .andDo(print())
+                .andDo(document("dashboard/team/save",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").description("팀 대시보드 제목"),
+                                fieldWithPath("description").description("팀 대시보드 설명")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.dashboardId").description("대시보드 아이디"),
+                                fieldWithPath("data.myId").description("내 아이디"),
+                                fieldWithPath("data.creatorId").description("팀 대시보드 생성자 아이디"),
+                                fieldWithPath("data.title").description("팀 대시보드 제목"),
+                                fieldWithPath("data.description").description("팀 대시보드 설명"),
+                                fieldWithPath("data.blockProgress").description("팀 대시보드의 완료된 블록 진행률"),
+                                fieldWithPath("data.joinMembers").description("팀 대시보드에 참여한 사용자")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("PATCH 팀 대시보드 수정 컨트롤러 로직 확인")
+    @Test
+    void 팀_대시보드_수정() throws Exception {
+        // given
+        teamDashboard.update(teamDashboardUpdateReqDto.title(), teamDashboardUpdateReqDto.description());
+        TeamDashboardInfoResDto response = TeamDashboardInfoResDto.of(member, teamDashboard);
+        given(teamDashboardService.update(anyString(), anyLong(), any(TeamDashboardUpdateReqDto.class)))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(patch("/api/dashboards/team/{dashboardId}", 1L)
+                        .header("Authorization", "Bearer valid-token")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(teamDashboardUpdateReqDto)))
+                .andDo(print())
+                .andDo(document("dashboard/team/update",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("dashboardId").description("대시보드 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").description("개인 대시보드 제목"),
+                                fieldWithPath("description").description("개인 대시보드 설명")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.dashboardId").description("대시보드 아이디"),
+                                fieldWithPath("data.myId").description("내 아이디"),
+                                fieldWithPath("data.creatorId").description("팀 대시보드 생성자 아이디"),
+                                fieldWithPath("data.title").description("팀 대시보드 제목"),
+                                fieldWithPath("data.description").description("팀 대시보드 설명"),
+                                fieldWithPath("data.blockProgress").description("팀 대시보드의 완료된 블록 진행률"),
+                                fieldWithPath("data.joinMembers").description("팀 대시보드에 참여한 사용자")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("GET 팀 대시보드를 전체 조회합니다.")
+    @Test
+    void 팀_대시보드_전체_조회() throws Exception {
+        // given
+        Page<TeamDashboard> teamDashboardPage = new PageImpl<>(
+                List.of(teamDashboard),
+                PageRequest.of(0, 10),
+                1
+        );
+        TeamDashboardListResDto response = TeamDashboardListResDto.of(
+                Collections.singletonList(TeamDashboardInfoResDto.of(member, teamDashboard)),
+                PageInfoResDto.from(teamDashboardPage)
+        );
+
+        given(teamDashboardService.findForTeamDashboard(anyString(), any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/dashboards/team/")
+                        .header("Authorization", "Bearer valid-token")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("dashboard/team/findForTeamDashboard",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.teamDashboardInfoResDto[].dashboardId")
+                                        .description("대시보드 아이디"),
+                                fieldWithPath("data.teamDashboardInfoResDto[].myId")
+                                        .description("내 아이디"),
+                                fieldWithPath("data.teamDashboardInfoResDto[].creatorId")
+                                        .description("팀 대시보드 생성자 아이디"),
+                                fieldWithPath("data.teamDashboardInfoResDto[].title")
+                                        .description("팀 대시보드 제목"),
+                                fieldWithPath("data.teamDashboardInfoResDto[].description")
+                                        .description("팀 대시보드 설명"),
+                                fieldWithPath("data.teamDashboardInfoResDto[].blockProgress")
+                                        .description("팀 대시보드의 완료된 블록 진행률"),
+                                fieldWithPath("data.teamDashboardInfoResDto[].joinMembers")
+                                        .description("팀 대시보드에 참여한 사용자"),
+                                fieldWithPath("data.pageInfoResDto.currentPage").description("현재 페이지"),
+                                fieldWithPath("data.pageInfoResDto.totalPages").description("전체 페이지"),
+                                fieldWithPath("data.pageInfoResDto.totalItems").description("전체 아이템")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("GET 팀 대시보드를 상세봅니다.")
+    @Test
+    void 팀_대시보드_상세보기() throws Exception {
+        // given
+        TeamDashboardInfoResDto response = TeamDashboardInfoResDto.of(member, teamDashboard);
+
+        given(teamDashboardService.findById(anyString(), anyLong())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/dashboards/team/{dashboardId}", 1L)
+                        .header("Authorization", "Bearer valid-token")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("dashboard/team/findById",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("dashboardId").description("대시보드 아이디")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.dashboardId").description("대시보드 아이디"),
+                                fieldWithPath("data.myId").description("내 아이디"),
+                                fieldWithPath("data.creatorId").description("팀 대시보드 생성자 아이디"),
+                                fieldWithPath("data.title").description("팀 대시보드 제목"),
+                                fieldWithPath("data.description").description("팀 대시보드 설명"),
+                                fieldWithPath("data.blockProgress").description("팀 대시보드의 완료된 블록 진행률"),
+                                fieldWithPath("data.joinMembers").description("팀 대시보드에 참여한 사용자")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("DELETE 팀 대시보드를 논리적으로 삭제하고 복구합니다.")
+    @Test
+    void 팀_대시보드_삭제() throws Exception {
+        // given
+        doNothing().when(teamDashboardService).delete(anyString(), anyLong());
+
+        // when & then
+        mockMvc.perform(delete("/api/dashboards/team/{dashboardId}", 1L)
+                        .header("Authorization", "Bearer valid-token")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("dashboard/team/delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("dashboardId").description("팀 대시보드 ID")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("POST 팀 대시보드 초대를 수락합니다.")
+    @Test
+    void 팀_대시보드_초대_수락() throws Exception {
+        // given
+        doNothing().when(teamDashboardService).joinTeam(anyString(), anyLong());
+
+        // when & then
+        mockMvc.perform(post("/api/dashboards/team/{dashboardId}/join", 1L)
+                        .header("Authorization", "Bearer valid-token")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("dashboard/team/join",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("dashboardId").description("팀 대시보드 ID")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("POST 참여한 팀 대시보드를 탈퇴합니다.")
+    @Test
+    void 팀_대시보드_탈퇴() throws Exception {
+        // given
+        doNothing().when(teamDashboardService).leaveTeam(anyString(), anyLong());
+
+        // when & then
+        mockMvc.perform(post("/api/dashboards/team/{dashboardId}/leave", 1L)
+                        .header("Authorization", "Bearer valid-token")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("dashboard/team/leave",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("dashboardId").description("팀 대시보드 ID")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("GET 팀원 초대 리스트를 조회합니다.")
+    @Test
+    void 팀_초대_멤버_조회() throws Exception {
+        // given
+        SearchMemberListResDto response = SearchMemberListResDto.from(List.of(joinMember));
+
+        given(teamDashboardService.searchMembers(anyString())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get(String.format("/api/dashboards/team/search?query=%s", "joinEmail"))
+                        .header("Authorization", "Bearer valid-token")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("dashboard/team/search",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        queryParameters(
+                                parameterWithName("query").description("검색 조건(이메일, 닉네임#고유번호)")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.searchMembers[].id").description("대시보드 아이디"),
+                                fieldWithPath("data.searchMembers[].picture").description("내 아이디"),
+                                fieldWithPath("data.searchMembers[].email").description("팀 대시보드 생성자 아이디")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardServiceTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardServiceTest.java
@@ -1,0 +1,274 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.team.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.exception.DashboardAccessDeniedException;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardSaveReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.request.TeamDashboardUpdateReqDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.SearchMemberListResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboardInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboardListResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.TeamDashboard;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.repository.TeamDashboardRepository;
+import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.domain.SocialType;
+import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class TeamDashboardServiceTest {
+
+    @Mock
+    private TeamDashboardRepository teamDashboardRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private TeamDashboardService teamDashboardService;
+
+    private Member member;
+    private TeamDashboard teamDashboard;
+    private TeamDashboard deleteTeamDashboard;
+    private TeamDashboardSaveReqDto teamDashboardSaveReqDto;
+    private TeamDashboardUpdateReqDto teamDashboardUpdateReqDto;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .email("email")
+                .name("name")
+                .nickname("nickname")
+                .socialType(SocialType.GOOGLE)
+                .introduction("introduction")
+                .picture("picture")
+                .build();
+
+        when(memberRepository.findByEmail(anyString())).thenReturn(Optional.ofNullable(member));
+
+        teamDashboardSaveReqDto = new TeamDashboardSaveReqDto("title", "description");
+        teamDashboardUpdateReqDto = new TeamDashboardUpdateReqDto("updateTitle", "updateDescription");
+
+        teamDashboard = TeamDashboard.builder()
+                .title(teamDashboardSaveReqDto.title())
+                .description(teamDashboardSaveReqDto.description())
+                .member(member)
+                .build();
+
+        deleteTeamDashboard = TeamDashboard.builder()
+                .title(teamDashboardSaveReqDto.title())
+                .description(teamDashboardSaveReqDto.description())
+                .member(member)
+                .build();
+        deleteTeamDashboard.statusUpdate();
+    }
+
+    @DisplayName("팀 대시보드를 저장합니다.")
+    @Test
+    void 팀_대시보드_저장() {
+        // given
+        when(teamDashboardRepository.save(any(TeamDashboard.class))).thenReturn(teamDashboard);
+
+        // when
+        TeamDashboardInfoResDto result = teamDashboardService.save(member.getEmail(), teamDashboardSaveReqDto);
+
+        // then
+        assertAll(() -> {
+            assertThat(result.title()).isEqualTo("title");
+            assertThat(result.description()).isEqualTo("description");
+        });
+    }
+
+    @DisplayName("팀 대시보드를 수정합니다.")
+    @Test
+    void 팀_대시보드_수정() {
+        // given
+        Long dashboardId = 1L;
+        when(teamDashboardRepository.findById(dashboardId)).thenReturn(Optional.of(teamDashboard));
+
+        // when
+        TeamDashboardInfoResDto result = teamDashboardService.update(
+                member.getEmail(),
+                dashboardId,
+                teamDashboardUpdateReqDto);
+
+        // then
+        assertAll(() -> {
+            assertThat(result.title()).isEqualTo("updateTitle");
+            assertThat(result.description()).isEqualTo("updateDescription");
+        });
+    }
+
+    @DisplayName("생성자가 아닌 사용자가 팀 대시보드를 수정하는데 실패합니다. (DashboardAccessDeniedException 발생)")
+    @Test
+    void 팀_대시보드_수정_실패() {
+        // given
+        Long dashboardId = 1L;
+        String unauthorizedEmail = "unauthorizedEmail@email.com";
+
+        Member unauthorizedMember = Member.builder()
+                .email(unauthorizedEmail)
+                .name("name")
+                .nickname("nickname")
+                .socialType(SocialType.GOOGLE)
+                .introduction("introduction")
+                .picture("picture")
+                .build();
+
+        when(memberRepository.findByEmail(unauthorizedEmail)).thenReturn(Optional.of(unauthorizedMember));
+        when(teamDashboardRepository.findById(dashboardId)).thenReturn(Optional.of(teamDashboard));
+
+        // when & then
+        assertThatThrownBy(
+                () -> teamDashboardService.update(unauthorizedEmail, dashboardId, teamDashboardUpdateReqDto)
+        ).isInstanceOf(DashboardAccessDeniedException.class);
+    }
+
+    @DisplayName("팀 대시보드를 삭제합니다.")
+    @Test
+    void 팀_대시보드_삭제() {
+        // given
+        Long dashboardId = 1L;
+        when(teamDashboardRepository.findById(dashboardId)).thenReturn(Optional.of(teamDashboard));
+
+        // when
+        teamDashboardService.delete(member.getEmail(), dashboardId);
+
+        // then
+        assertAll(() -> {
+            assertThat(teamDashboard.getStatus()).isEqualTo(Status.DELETED);
+        });
+    }
+
+    @DisplayName("팀 대시보드를 전체 조회합니다.")
+    @Test
+    void 팀_대시보드_전체_조회() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<TeamDashboard> teamDashboardPage = new PageImpl<>(
+                List.of(teamDashboard),
+                pageable,
+                1);
+
+        when(teamDashboardRepository.findForTeamDashboard(any(Member.class), any(Pageable.class)))
+                .thenReturn(teamDashboardPage);
+
+        // when
+        TeamDashboardListResDto result = teamDashboardService.
+                findForTeamDashboard(member.getEmail(), pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.teamDashboardInfoResDto()).hasSize(1);
+    }
+
+    @DisplayName("팀 대시보드를 상세 봅니다.")
+    @Test
+    void 팀_대시보드_상세보기() {
+        // given
+        Long dashboardId = 1L;
+        when(teamDashboardRepository.findById(dashboardId)).thenReturn(Optional.of(teamDashboard));
+
+        // when
+        TeamDashboardInfoResDto result = teamDashboardService.findById(member.getEmail(), dashboardId);
+
+        // then
+        assertAll(() -> {
+            assertThat(result.title()).isEqualTo("title");
+            assertThat(result.description()).isEqualTo("description");
+            assertThat(result.blockProgress()).isEqualTo(0.0);
+        });
+    }
+
+    @DisplayName("삭제되었던 팀 대시보드를 복구합니다.")
+    @Test
+    void 팀_대시보드_복구() {
+        // given
+        Long dashboardId = 1L;
+        when(teamDashboardRepository.findById(dashboardId)).thenReturn(Optional.of(deleteTeamDashboard));
+
+        // when
+        teamDashboardService.delete(member.getEmail(), dashboardId);
+
+        // then
+        assertAll(() -> {
+            assertThat(deleteTeamDashboard.getStatus()).isEqualTo(Status.ACTIVE);
+        });
+    }
+
+    @DisplayName("팀 대시보드에 참여합니다")
+    @Test
+    void 팀_대시보드_참여() {
+        // given
+        Long dashboardId = 1L;
+        when(teamDashboardRepository.findById(dashboardId)).thenReturn(Optional.of(teamDashboard));
+
+        // when
+        teamDashboardService.joinTeam(member.getEmail(), dashboardId);
+        TeamDashboardInfoResDto result = teamDashboardService.findById(member.getEmail(), dashboardId);
+
+        // then
+        assertAll(() -> {
+            assertThat(result.title()).isEqualTo("title");
+            assertThat(result.description()).isEqualTo("description");
+            assertThat(result.blockProgress()).isEqualTo(0.0);
+            assertThat(result.joinMembers().size()).isEqualTo(1);
+        });
+    }
+
+    @DisplayName("팀 대시보드를 탈퇴합니다.")
+    @Test
+    void 팀_대시보드_탈퇴() {
+        // given
+        Long dashboardId = 1L;
+        when(teamDashboardRepository.findById(dashboardId)).thenReturn(Optional.of(teamDashboard));
+
+        // when
+        teamDashboardService.joinTeam(member.getEmail(), dashboardId);
+        teamDashboardService.leaveTeam(member.getEmail(), dashboardId);
+        TeamDashboardInfoResDto result = teamDashboardService.findById(member.getEmail(), dashboardId);
+
+        // then
+        assertAll(() -> {
+            assertThat(result.title()).isEqualTo("title");
+            assertThat(result.description()).isEqualTo("description");
+            assertThat(result.blockProgress()).isEqualTo(0.0);
+            assertThat(result.joinMembers().size()).isEqualTo(0);
+        });
+    }
+
+    @DisplayName("팀원 초대 리스트를 조회합니다.")
+    @Test
+    void 팀_초대_멤버_조회() {
+        // given
+        String query = "email";
+        when(teamDashboardRepository.findForMembersByQuery(query)).thenReturn(List.of(member));
+
+        // when
+        SearchMemberListResDto result = teamDashboardService.searchMembers(query);
+
+        // then
+        assertAll(() -> {
+            assertThat(result.searchMembers().size()).isEqualTo(1);
+        });
+    }
+
+}

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardServiceTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -62,7 +63,7 @@ class TeamDashboardServiceTest {
                 .picture("picture")
                 .build();
 
-        when(memberRepository.findByEmail(anyString())).thenReturn(Optional.ofNullable(member));
+        lenient().when(memberRepository.findByEmail(anyString())).thenReturn(Optional.ofNullable(member));
 
         teamDashboardSaveReqDto = new TeamDashboardSaveReqDto("title", "description");
         teamDashboardUpdateReqDto = new TeamDashboardUpdateReqDto("updateTitle", "updateDescription");

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/TeamDashboardTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/TeamDashboardTest.java
@@ -1,0 +1,98 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.team.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.domain.SocialType;
+
+class TeamDashboardTest {
+
+    private Member member;
+    private TeamDashboard teamDashboard;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .email("email")
+                .name("name")
+                .nickname("nickname")
+                .socialType(SocialType.GOOGLE)
+                .introduction("introduction")
+                .picture("picture")
+                .build();
+        teamDashboard = TeamDashboard.builder()
+                .title("title")
+                .description("description")
+                .build();
+    }
+
+    @DisplayName("팀 대시보드의 모든 값을 수정합니다.")
+    @Test
+    void 팀_대시보드_수정() {
+        // given
+        String updateTitle = "updateTitle";
+        String updateDescription = "updateDescription";
+
+        // when
+        teamDashboard.update(updateTitle, updateDescription);
+
+        // then
+        assertAll(() -> {
+            assertThat(teamDashboard.getTitle()).isEqualTo(updateTitle);
+            assertThat(teamDashboard.getDescription()).isEqualTo(updateDescription);
+        });
+    }
+
+    @DisplayName("팀 대시보드 논리 삭제 상태를 수정합니다.")
+    @Test
+    void 팀_대시보드_상태_수정() {
+        // given
+        assertThat(teamDashboard.getStatus()).isEqualTo(Status.ACTIVE);
+
+        // when
+        teamDashboard.statusUpdate();
+
+        // then
+        assertThat(teamDashboard.getStatus()).isEqualTo(Status.DELETED);
+
+        // when
+        teamDashboard.statusUpdate();
+
+        // then
+        assertThat(teamDashboard.getStatus()).isEqualTo(Status.ACTIVE);
+    }
+
+    @DisplayName("팀 대시보드에 참가합니다.")
+    @Test
+    void 팀_대시보드_참가() {
+        // given
+        assertTrue(teamDashboard.getTeamDashboardMemberMappings().isEmpty());
+
+        // when
+        teamDashboard.addMember(member);
+
+        // then
+        assertThat(teamDashboard.getTeamDashboardMemberMappings().size()).isEqualTo(1);
+    }
+
+    @DisplayName("팀 대시보드 탈퇴")
+    @Test
+    void 팀_대시보드_탈퇴() {
+        // given
+        teamDashboard.addMember(member);
+        assertThat(teamDashboard.getTeamDashboardMemberMappings().size()).isEqualTo(1);
+
+        // when
+        teamDashboard.removeMember(member);
+
+        // then
+        assertThat(teamDashboard.getTeamDashboardMemberMappings().size()).isEqualTo(0);
+    }
+
+}

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/repository/TeamDashboardRepositoryTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/domain/repository/TeamDashboardRepositoryTest.java
@@ -1,0 +1,141 @@
+package shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Progress;
+import shop.kkeujeok.kkeujeokbackend.block.domain.repository.BlockRepository;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.TeamDashboard;
+import shop.kkeujeok.kkeujeokbackend.global.config.JpaAuditingConfig;
+import shop.kkeujeok.kkeujeokbackend.global.config.QuerydslConfig;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.domain.SocialType;
+import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
+
+@DataJpaTest
+@Import({JpaAuditingConfig.class, QuerydslConfig.class})
+@ActiveProfiles("test")
+class TeamDashboardRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BlockRepository blockRepository;
+
+    @Autowired
+    private TeamDashboardRepository teamDashboardRepository;
+
+    private Member member;
+    private TeamDashboard teamDashboard;
+    private Block block1;
+    private Block block2;
+    private Block block3;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .email("email")
+                .name("name")
+                .nickname("nickname")
+                .socialType(SocialType.GOOGLE)
+                .introduction("introduction")
+                .picture("picture")
+                .tag("#0000")
+                .build();
+
+        memberRepository.save(member);
+
+        teamDashboard = TeamDashboard.builder()
+                .member(member)
+                .title("title")
+                .description("description")
+                .build();
+
+        teamDashboardRepository.save(teamDashboard);
+
+        block1 = Block.builder()
+                .title("title1")
+                .contents("contents1")
+                .progress(Progress.COMPLETED)
+                .deadLine("2024.07.27 11:03")
+                .dashboard(teamDashboard)
+                .build();
+
+        block2 = Block.builder()
+                .title("title2")
+                .contents("contents2")
+                .progress(Progress.NOT_STARTED)
+                .deadLine("2024.07.27 11:04")
+                .dashboard(teamDashboard)
+                .build();
+
+        block3 = Block.builder()
+                .title("title3")
+                .contents("contents3")
+                .progress(Progress.COMPLETED)
+                .deadLine("2024.07.27 11:05")
+                .dashboard(teamDashboard)
+                .build();
+
+        blockRepository.save(block1);
+        blockRepository.save(block2);
+        blockRepository.save(block3);
+    }
+
+    @DisplayName("팀 대시보드를 전체 조회합니다.")
+    @Test
+    void 팀_대시보드_전체_조회() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<TeamDashboard> result = teamDashboardRepository.findForTeamDashboard(member, pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("title");
+        assertThat(result.getContent().get(0).getMember()).isEqualTo(member);
+    }
+
+    @DisplayName("팀 대시보드를 생성할 때 초대 멤버 리스트를 조회합니다.")
+    @Test
+    void 초대_멤버_조회() {
+        // given
+        String query1 = "email";
+        String query2 = "nickname#0000";
+
+        // when
+        List<Member> result1 = teamDashboardRepository.findForMembersByQuery(query1);
+        List<Member> result2 = teamDashboardRepository.findForMembersByQuery(query2);
+
+        // then
+        assertThat(result1.size()).isEqualTo(1);
+        assertThat(result1.get(0).getName()).isEqualTo("name");
+
+        assertThat(result2.size()).isEqualTo(1);
+    }
+
+    @DisplayName("대시보드의 완료된 블록 비율을 계산합니다.")
+    @Test
+    void 팀_대시보드_완료_블록_비율_계산() {
+        // when
+        double completionPercentage = teamDashboardRepository
+                .calculateCompletionPercentage(teamDashboard.getId());
+
+        // then
+        assertThat(completionPercentage).isEqualTo(66.67, offset(0.01));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #67 #62 

## 📝작업 내용

> 팀 대시보드 기능을 구현했습니다.
> 팀원 초대 리스트 api에서 쿼리스트링으로 query를 요청합니다.
여기서 query는 "이메일" 또는 "닉네임#고유번호" 입니다.


> 팀 대시보드를 구현하면서 개인 대시보드 삭제 메시지와 query를 수정해야할 부분이 있어서 수정했습니다.

