### PR TITLE
Feat(#197): 친구 추가 요청, 수락, 예외처리 로직 

### DIFF
--- a/src/docs/asciidoc/follow.adoc
+++ b/src/docs/asciidoc/follow.adoc
@@ -6,15 +6,12 @@
 
 include::{snippets}/follow/save/http-request.adoc[]
 include::{snippets}/follow/save/request-fields.adoc[]
+include::{snippets}/follow/accept/request-headers.adoc[]
 
 === 응답
 
 include::{snippets}/follow/save/http-response.adoc[]
 include::{snippets}/follow/save/response-fields.adoc[]
-
-== 친구 요청 수락 API
-
-=== 요청
 
 == 친구 요청 수락 API
 
@@ -34,6 +31,7 @@ include::{snippets}/follow/accept/response-fields.adoc[]
 
 include::{snippets}/follow/findFollowList/http-request.adoc[]
 include::{snippets}/follow/findFollowList/query-parameters.adoc[]
+include::{snippets}/follow/accept/request-headers.adoc[]
 
 === 응답
 
@@ -46,6 +44,7 @@ include::{snippets}/follow/findFollowList/response-fields.adoc[]
 
 include::{snippets}/follow/findRecommendedFollowList/http-request.adoc[]
 include::{snippets}/follow/findRecommendedFollowList/query-parameters.adoc[]
+include::{snippets}/follow/accept/request-headers.adoc[]
 
 === 응답
 
@@ -58,6 +57,7 @@ include::{snippets}/follow/findRecommendedFollowList/response-fields.adoc[]
 
 include::{snippets}/follow/delete/http-request.adoc[]
 include::{snippets}/follow/delete/path-parameters.adoc[]
+include::{snippets}/follow/accept/request-headers.adoc[]
 
 === 응답
 
@@ -70,6 +70,7 @@ include::{snippets}/follow/delete/response-fields.adoc[]
 
 include::{snippets}/follow/searchRecommendedFollowUsingKeywords/http-request.adoc[]
 include::{snippets}/follow/searchRecommendedFollowUsingKeywords/query-parameters.adoc[]
+include::{snippets}/follow/accept/request-headers.adoc[]
 
 === 응답
 

--- a/src/docs/asciidoc/follow.adoc
+++ b/src/docs/asciidoc/follow.adoc
@@ -1,0 +1,77 @@
+= 친구 API 문서
+
+== 친구 추가 요청 API
+
+=== 요청
+
+include::{snippets}/follow/save/http-request.adoc[]
+include::{snippets}/follow/save/request-fields.adoc[]
+
+=== 응답
+
+include::{snippets}/follow/save/http-response.adoc[]
+include::{snippets}/follow/save/response-fields.adoc[]
+
+== 친구 요청 수락 API
+
+=== 요청
+
+== 친구 요청 수락 API
+
+=== 요청
+
+include::{snippets}/follow/accept/http-request.adoc[]
+include::{snippets}/follow/accept/path-parameters.adoc[]
+
+=== 응답
+
+include::{snippets}/follow/accept/http-response.adoc[]
+include::{snippets}/follow/accept/response-fields.adoc[]
+
+== 내 친구 목록 조회 API
+
+=== 요청
+
+include::{snippets}/follow/findFollowList/http-request.adoc[]
+include::{snippets}/follow/findFollowList/query-parameters.adoc[]
+
+=== 응답
+
+include::{snippets}/follow/findFollowList/http-response.adoc[]
+include::{snippets}/follow/findFollowList/response-fields.adoc[]
+
+== 추천 친구 목록 조회 API
+
+=== 요청
+
+include::{snippets}/follow/findRecommendedFollowList/http-request.adoc[]
+include::{snippets}/follow/findRecommendedFollowList/query-parameters.adoc[]
+
+=== 응답
+
+include::{snippets}/follow/findRecommendedFollowList/http-response.adoc[]
+include::{snippets}/follow/findRecommendedFollowList/response-fields.adoc[]
+
+== 친구 삭제 API
+
+=== 요청
+
+include::{snippets}/follow/delete/http-request.adoc[]
+include::{snippets}/follow/delete/path-parameters.adoc[]
+
+=== 응답
+
+include::{snippets}/follow/delete/http-response.adoc[]
+include::{snippets}/follow/delete/response-fields.adoc[]
+
+== 키워드로 추천 친구 목록 조회 API
+
+=== 요청
+
+include::{snippets}/follow/searchRecommendedFollowUsingKeywords/http-request.adoc[]
+include::{snippets}/follow/searchRecommendedFollowUsingKeywords/query-parameters.adoc[]
+
+=== 응답
+
+include::{snippets}/follow/searchRecommendedFollowUsingKeywords/http-response.adoc[]
+include::{snippets}/follow/searchRecommendedFollowUsingKeywords/response-fields.adoc[]

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/domain/Member.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/domain/Member.java
@@ -15,6 +15,7 @@ import shop.kkeujeok.kkeujeokbackend.challenge.domain.Challenge;
 import shop.kkeujeok.kkeujeokbackend.challenge.domain.ChallengeMemberMapping;
 import shop.kkeujeok.kkeujeokbackend.global.entity.BaseEntity;
 import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
+import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
 import shop.kkeujeok.kkeujeokbackend.notification.domain.Notification;
 
 @Entity
@@ -53,6 +54,12 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     private List<ChallengeMemberMapping> challengeMemberMappings;
+
+    @OneToMany(mappedBy = "from_member", fetch = FetchType.LAZY)
+    private List<Follow> followings;
+
+    @OneToMany(mappedBy = "to_member", fetch = FetchType.LAZY)
+    private List<Follow> followers;
 
     @Builder
     private Member(Status status, Role role,

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/domain/Member.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/domain/Member.java
@@ -58,9 +58,6 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "fromMember", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     private List<Follow> followings;
 
-    @OneToMany(mappedBy = "toMember", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-    private List<Follow> followers;
-
     @Builder
     private Member(Status status, Role role,
                    String email, String name,

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/domain/Member.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/domain/Member.java
@@ -55,10 +55,10 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     private List<ChallengeMemberMapping> challengeMemberMappings;
 
-    @OneToMany(mappedBy = "from_member", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "fromMember", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     private List<Follow> followings;
 
-    @OneToMany(mappedBy = "to_member", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "toMember", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     private List<Follow> followers;
 
     @Builder

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowController.java
@@ -1,0 +1,29 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shop.kkeujeok.kkeujeokbackend.global.annotation.CurrentUserEmail;
+import shop.kkeujeok.kkeujeokbackend.global.template.RspTemplate;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request.FollowReqDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowResDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.application.FollowService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/member/follow")
+public class FollowController {
+
+    private final FollowService followService;
+
+    @PostMapping("")
+    public RspTemplate<FollowResDto> save(@CurrentUserEmail String email,
+                                          @RequestBody FollowReqDto followReqDto) {
+        return new RspTemplate<>(HttpStatus.OK,
+                "친구 추가 요청",
+                followService.save(email, followReqDto));
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowController.java
@@ -69,4 +69,14 @@ public class FollowController {
         return new RspTemplate<>(HttpStatus.OK,
                 "친구 삭제");
     }
+
+    @GetMapping("/search")
+    public RspTemplate<RecommendedFollowInfoListDto> searchRecommendedFollowUsingKeywords(@CurrentUserEmail String email,
+                                                                                          @RequestParam(name = "keyword") String keyword,
+                                                                                          @RequestParam(name = "page", defaultValue = "0") int page,
+                                                                                          @RequestParam(name = "size", defaultValue = "10") int size) {
+        return new RspTemplate<>(HttpStatus.OK,
+                "키워드로 추천 친구 목록 조회",
+                followService.searchRecommendedFollowUsingKeywords(email, keyword, PageRequest.of(page, size)));
+    }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowController.java
@@ -3,6 +3,7 @@ package shop.kkeujeok.kkeujeokbackend.member.follow.api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,7 +41,7 @@ public class FollowController {
         followService.accept(followId);
 
         return new RspTemplate<>(HttpStatus.OK,
-                "친구 추가 수락", null);
+                "친구 추가 수락");
     }
 
     @GetMapping
@@ -59,5 +60,13 @@ public class FollowController {
         return new RspTemplate<>(HttpStatus.OK,
                 "추천 친구 목록 조회",
                 followService.findRecommendedFollowList(email, PageRequest.of(page, size)));
+    }
+
+    @DeleteMapping("/{memberId}")
+    public RspTemplate<Void> delete(@CurrentUserEmail String email, @PathVariable Long memberId) {
+        followService.delete(email, memberId);
+
+        return new RspTemplate<>(HttpStatus.OK,
+                "친구 삭제");
     }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowController.java
@@ -2,6 +2,7 @@ package shop.kkeujeok.kkeujeokbackend.member.follow.api;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +22,7 @@ public class FollowController {
 
     private final FollowService followService;
 
-    @PostMapping("")
+    @PostMapping
     public RspTemplate<FollowResDto> save(@CurrentUserEmail String email,
                                           @RequestBody FollowReqDto followReqDto) {
         return new RspTemplate<>(HttpStatus.OK,
@@ -29,10 +30,11 @@ public class FollowController {
                 followService.save(email, followReqDto));
     }
 
-    @PostMapping("/accept")
-    public RspTemplate<FollowAcceptResDto> accept(@RequestBody FollowAcceptReqDto followAcceptReqDto) {
+    @PostMapping("/accept/{followId}")
+    public RspTemplate<Void> accept(@PathVariable Long followId) {
+        followService.accept(followId);
+
         return new RspTemplate<>(HttpStatus.OK,
-                "친구 추가 수락",
-                followService.accept(followAcceptReqDto));
+                "친구 추가 수락", null);
     }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowController.java
@@ -17,6 +17,7 @@ import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request.FollowReqDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowAcceptResDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowInfoListDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowResDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.RecommendedFollowInfoListDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.application.FollowService;
 
 @RestController
@@ -49,5 +50,14 @@ public class FollowController {
         return new RspTemplate<>(HttpStatus.OK,
                 "내 친구 목록 조회",
                 followService.findFollowList(email, PageRequest.of(page, size)));
+    }
+
+    @GetMapping("/recommended")
+    public RspTemplate<RecommendedFollowInfoListDto> findRecommendedFollowList(@CurrentUserEmail String email,
+                                                                               @RequestParam(name = "page", defaultValue = "0") int page,
+                                                                               @RequestParam(name = "size", defaultValue = "10") int size) {
+        return new RspTemplate<>(HttpStatus.OK,
+                "추천 친구 목록 조회",
+                followService.findRecommendedFollowList(email, PageRequest.of(page, size)));
     }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowController.java
@@ -8,7 +8,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import shop.kkeujeok.kkeujeokbackend.global.annotation.CurrentUserEmail;
 import shop.kkeujeok.kkeujeokbackend.global.template.RspTemplate;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request.FollowAcceptReqDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request.FollowReqDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowAcceptResDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowResDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.application.FollowService;
 
@@ -25,5 +27,12 @@ public class FollowController {
         return new RspTemplate<>(HttpStatus.OK,
                 "친구 추가 요청",
                 followService.save(email, followReqDto));
+    }
+
+    @PostMapping("/accept")
+    public RspTemplate<FollowAcceptResDto> accept(@RequestBody FollowAcceptReqDto followAcceptReqDto) {
+        return new RspTemplate<>(HttpStatus.OK,
+                "친구 추가 수락",
+                followService.accept(followAcceptReqDto));
     }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowController.java
@@ -1,17 +1,21 @@
 package shop.kkeujeok.kkeujeokbackend.member.follow.api;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import shop.kkeujeok.kkeujeokbackend.global.annotation.CurrentUserEmail;
 import shop.kkeujeok.kkeujeokbackend.global.template.RspTemplate;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request.FollowAcceptReqDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request.FollowReqDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowAcceptResDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowInfoListDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowResDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.application.FollowService;
 
@@ -36,5 +40,14 @@ public class FollowController {
 
         return new RspTemplate<>(HttpStatus.OK,
                 "친구 추가 수락", null);
+    }
+
+    @GetMapping
+    public RspTemplate<FollowInfoListDto> findFollowList(@CurrentUserEmail String email,
+                                                         @RequestParam(name = "page", defaultValue = "0") int page,
+                                                         @RequestParam(name = "size", defaultValue = "10") int size) {
+        return new RspTemplate<>(HttpStatus.OK,
+                "내 친구 목록 조회",
+                followService.findFollowList(email, PageRequest.of(page, size)));
     }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/request/FollowAcceptReqDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/request/FollowAcceptReqDto.java
@@ -1,0 +1,6 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request;
+
+public record FollowAcceptReqDto(
+        Long followId
+) {
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/request/FollowReqDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/request/FollowReqDto.java
@@ -1,0 +1,16 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request;
+
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
+import shop.kkeujeok.kkeujeokbackend.member.follow.domain.FollowStatus;
+
+public record FollowReqDto(
+        Long memberId) {
+    public Follow toEntity(Member fromMember, Member toMember) {
+        return Follow.builder()
+                .fromMember(fromMember)
+                .toMember(toMember)
+                .followStatus(FollowStatus.UN_ACTIVE)
+                .build();
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/request/FollowReqDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/request/FollowReqDto.java
@@ -5,12 +5,13 @@ import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
 import shop.kkeujeok.kkeujeokbackend.member.follow.domain.FollowStatus;
 
 public record FollowReqDto(
-        Long memberId) {
+        Long memberId
+) {
     public Follow toEntity(Member fromMember, Member toMember) {
         return Follow.builder()
                 .fromMember(fromMember)
                 .toMember(toMember)
-                .followStatus(FollowStatus.UN_ACTIVE)
+                .followStatus(FollowStatus.WAIT)
                 .build();
     }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/FollowAcceptResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/FollowAcceptResDto.java
@@ -1,0 +1,17 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response;
+
+import lombok.Builder;
+import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
+
+@Builder
+public record FollowAcceptResDto(
+        Long fromMemberId,
+        Long toMemberId
+) {
+    public static FollowAcceptResDto from(Follow follow) {
+        return FollowAcceptResDto.builder()
+                .fromMemberId(follow.getFromMember().getId())
+                .toMemberId(follow.getToMember().getId())
+                .build();
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/FollowInfoListDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/FollowInfoListDto.java
@@ -9,7 +9,7 @@ public record FollowInfoListDto(
         List<FollowInfoResDto> followInfoResDto,
         PageInfoResDto pageInfoResDto
 ) {
-    public static FollowInfoListDto from(List<FollowInfoResDto> follows, PageInfoResDto pageInfoResDto) {
+    public static FollowInfoListDto of(List<FollowInfoResDto> follows, PageInfoResDto pageInfoResDto) {
         return FollowInfoListDto.builder()
                 .followInfoResDto(follows)
                 .pageInfoResDto(pageInfoResDto)

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/FollowInfoListDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/FollowInfoListDto.java
@@ -1,0 +1,18 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import shop.kkeujeok.kkeujeokbackend.global.dto.PageInfoResDto;
+
+@Builder
+public record FollowInfoListDto(
+        List<FollowInfoResDto> followInfoResDto,
+        PageInfoResDto pageInfoResDto
+) {
+    public static FollowInfoListDto from(List<FollowInfoResDto> follows, PageInfoResDto pageInfoResDto) {
+        return FollowInfoListDto.builder()
+                .followInfoResDto(follows)
+                .pageInfoResDto(pageInfoResDto)
+                .build();
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/FollowInfoResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/FollowInfoResDto.java
@@ -1,0 +1,26 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response;
+
+import lombok.Builder;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
+
+@Builder
+public record FollowInfoResDto(
+        Long memberId,
+        String nickname,
+        String name,
+        String profileImage
+) {
+    public static FollowInfoResDto from(Follow follow, Long myMemberId) {
+        Member friend = follow.getToMember().getId().equals(myMemberId)
+                ? follow.getFromMember()
+                : follow.getToMember();
+
+        return FollowInfoResDto.builder()
+                .memberId(friend.getId())
+                .nickname(friend.getNickname())
+                .name(friend.getName())
+                .profileImage(friend.getPicture())
+                .build();
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/FollowInfoResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/FollowInfoResDto.java
@@ -11,7 +11,7 @@ public record FollowInfoResDto(
         String name,
         String profileImage
 ) {
-    public static FollowInfoResDto from(Follow follow, Long myMemberId) {
+    public static FollowInfoResDto of(Follow follow, Long myMemberId) {
         Member friend = follow.getToMember().getId().equals(myMemberId)
                 ? follow.getFromMember()
                 : follow.getToMember();

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/FollowResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/FollowResDto.java
@@ -1,0 +1,15 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response;
+
+import lombok.Builder;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
+
+@Builder
+public record FollowResDto(
+        Long toMemberId) {
+    public static FollowResDto from(Member member) {
+        return FollowResDto.builder()
+                .toMemberId(member.getId())
+                .build();
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/FollowResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/FollowResDto.java
@@ -6,7 +6,8 @@ import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
 
 @Builder
 public record FollowResDto(
-        Long toMemberId) {
+        Long toMemberId
+) {
     public static FollowResDto from(Member member) {
         return FollowResDto.builder()
                 .toMemberId(member.getId())

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/RecommendedFollowInfoListDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/RecommendedFollowInfoListDto.java
@@ -1,0 +1,19 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import shop.kkeujeok.kkeujeokbackend.global.dto.PageInfoResDto;
+
+@Builder
+public record RecommendedFollowInfoListDto(
+        List<RecommendedFollowInfoResDto> recommendedFollowInfoResDtos,
+        PageInfoResDto pageInfoResDto
+) {
+    public static RecommendedFollowInfoListDto of(List<RecommendedFollowInfoResDto> infoResDtos,
+                                                  PageInfoResDto pageInfoResDto) {
+        return RecommendedFollowInfoListDto.builder()
+                .recommendedFollowInfoResDtos(infoResDtos)
+                .pageInfoResDto(pageInfoResDto)
+                .build();
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/RecommendedFollowInfoResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/dto/response/RecommendedFollowInfoResDto.java
@@ -1,0 +1,22 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response;
+
+import lombok.Builder;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
+
+@Builder
+public record RecommendedFollowInfoResDto(
+        Long memberId,
+        String nickname,
+        String name,
+        String profileImage
+) {
+    public static RecommendedFollowInfoResDto from(Member member) {
+        return RecommendedFollowInfoResDto.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .name(member.getName())
+                .profileImage(member.getPicture())
+                .build();
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
@@ -86,7 +86,18 @@ public class FollowService {
 
         followRepository.delete(follow);
     }
-//    todo
-//     친구 검색 기능 (email, 혹은 닉네임#고유번호로)
-//     친구 삭제 로직
+
+    public RecommendedFollowInfoListDto searchRecommendedFollowUsingKeywords(String email,
+                                                                             String keyword,
+                                                                             Pageable pageable) {
+        Long memberId = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new).getId();
+
+        Page<RecommendedFollowInfoResDto> recommendedFollowInfoResDtos =
+                followRepository.searchRecommendedFollowUsingKeywords(memberId, keyword, pageable);
+
+        return RecommendedFollowInfoListDto.of(
+                recommendedFollowInfoResDtos.getContent(),
+                PageInfoResDto.from(recommendedFollowInfoResDtos)
+        );
+    }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
@@ -1,0 +1,42 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
+import shop.kkeujeok.kkeujeokbackend.member.exception.MemberNotFoundException;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request.FollowReqDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowResDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
+import shop.kkeujeok.kkeujeokbackend.member.follow.domain.repository.FollowRepository;
+import shop.kkeujeok.kkeujeokbackend.member.follow.exception.FollowNotFoundException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FollowService {
+
+    private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+
+    @Transactional
+    public FollowResDto save(String email, FollowReqDto followReqDto) {
+        Member fromMember = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        Member toMember = memberRepository.findById(followReqDto.memberId()).orElseThrow(FollowNotFoundException::new);
+
+        Follow follow = followReqDto.toEntity(fromMember,toMember);
+
+        followRepository.save(follow);
+
+        return FollowResDto.from(toMember);
+    }
+
+
+    // 이미 요청했으면 거절하는 로직
+    // 친구 요청 수락 로직 - 수락한 상태에서 또 요청하면 이미 친구라고 처리하는 로직
+    // 친구 리스트 보는 로직
+    // 추천 친구 리스트 보는 로직
+    // 친구 검색 기능 (email, 혹은 닉네임#고유번호로)
+    // 친구 삭제 로직
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
@@ -6,12 +6,15 @@ import org.springframework.transaction.annotation.Transactional;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
 import shop.kkeujeok.kkeujeokbackend.member.exception.MemberNotFoundException;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request.FollowAcceptReqDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request.FollowReqDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowAcceptResDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowResDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
 import shop.kkeujeok.kkeujeokbackend.member.follow.domain.repository.FollowRepository;
 import shop.kkeujeok.kkeujeokbackend.member.follow.exception.FollowAlreadyExistsException;
 import shop.kkeujeok.kkeujeokbackend.member.follow.exception.FollowNotFoundException;
+import software.amazon.awssdk.services.s3.endpoints.internal.Value.Str;
 
 @Service
 @RequiredArgsConstructor
@@ -42,7 +45,15 @@ public class FollowService {
         }
     }
 
-    // 친구 요청 수락 로직 - 수락한 상태에서 또 요청하면 이미 친구라고 처리하는 로직
+    @Transactional
+    public FollowAcceptResDto accept(FollowAcceptReqDto followAcceptReqDto) {
+        Follow follow = followRepository.findById(followAcceptReqDto.followId())
+                .orElseThrow(FollowNotFoundException::new);
+
+        followRepository.acceptFollowingRequest(followAcceptReqDto.followId());
+
+        return FollowAcceptResDto.from(follow);
+    }
     // 친구 리스트 보는 로직
     // 추천 친구 리스트 보는 로직
     // 친구 검색 기능 (email, 혹은 닉네임#고유번호로)

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
@@ -46,16 +46,13 @@ public class FollowService {
     }
 
     @Transactional
-    public FollowAcceptResDto accept(FollowAcceptReqDto followAcceptReqDto) {
-        Follow follow = followRepository.findById(followAcceptReqDto.followId())
-                .orElseThrow(FollowNotFoundException::new);
-
-        followRepository.acceptFollowingRequest(followAcceptReqDto.followId());
-
-        return FollowAcceptResDto.from(follow);
+    public void accept(Long followId) {
+        followRepository.acceptFollowingRequest(followId);
     }
-    // 친구 리스트 보는 로직
-    // 추천 친구 리스트 보는 로직
-    // 친구 검색 기능 (email, 혹은 닉네임#고유번호로)
-    // 친구 삭제 로직
+
+//    todo
+//     친구 리스트 보는 로직
+//     추천 친구 리스트 보는 로직
+//     친구 검색 기능 (email, 혹은 닉네임#고유번호로)
+//     친구 삭제 로직
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
@@ -1,14 +1,19 @@
 package shop.kkeujeok.kkeujeokbackend.member.follow.application;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import shop.kkeujeok.kkeujeokbackend.global.dto.PageInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
 import shop.kkeujeok.kkeujeokbackend.member.exception.MemberNotFoundException;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request.FollowAcceptReqDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request.FollowReqDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowAcceptResDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowInfoListDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowResDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
 import shop.kkeujeok.kkeujeokbackend.member.follow.domain.repository.FollowRepository;
@@ -29,10 +34,9 @@ public class FollowService {
         Member fromMember = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Member toMember = memberRepository.findById(followReqDto.memberId()).orElseThrow(FollowNotFoundException::new);
 
-
         validateFollowDoesNotExist(fromMember, toMember);
 
-        Follow follow = followReqDto.toEntity(fromMember,toMember);
+        Follow follow = followReqDto.toEntity(fromMember, toMember);
 
         followRepository.save(follow);
 
@@ -50,8 +54,18 @@ public class FollowService {
         followRepository.acceptFollowingRequest(followId);
     }
 
+    public FollowInfoListDto findFollowList(String email, Pageable pageable) {
+        Long memberId = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new).getId();
+
+        Page<FollowInfoResDto> followInfoResDtos = followRepository.findFollowList(memberId, pageable);
+
+        return FollowInfoListDto.from(
+                followInfoResDtos.getContent(),
+                PageInfoResDto.from(followInfoResDtos)
+        );
+    }
+
 //    todo
-//     친구 리스트 보는 로직
 //     추천 친구 리스트 보는 로직
 //     친구 검색 기능 (email, 혹은 닉네임#고유번호로)
 //     친구 삭제 로직

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
@@ -10,6 +10,7 @@ import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request.FollowReqDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowResDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
 import shop.kkeujeok.kkeujeokbackend.member.follow.domain.repository.FollowRepository;
+import shop.kkeujeok.kkeujeokbackend.member.follow.exception.FollowAlreadyExistsException;
 import shop.kkeujeok.kkeujeokbackend.member.follow.exception.FollowNotFoundException;
 
 @Service
@@ -25,6 +26,9 @@ public class FollowService {
         Member fromMember = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Member toMember = memberRepository.findById(followReqDto.memberId()).orElseThrow(FollowNotFoundException::new);
 
+
+        validateFollowDoesNotExist(fromMember, toMember);
+
         Follow follow = followReqDto.toEntity(fromMember,toMember);
 
         followRepository.save(follow);
@@ -32,8 +36,12 @@ public class FollowService {
         return FollowResDto.from(toMember);
     }
 
+    private void validateFollowDoesNotExist(Member fromMember, Member toMember) {
+        if (followRepository.existsByFromMemberAndToMember(fromMember, toMember)) {
+            throw new FollowAlreadyExistsException();
+        }
+    }
 
-    // 이미 요청했으면 거절하는 로직
     // 친구 요청 수락 로직 - 수락한 상태에서 또 요청하면 이미 친구라고 처리하는 로직
     // 친구 리스트 보는 로직
     // 추천 친구 리스트 보는 로직

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
@@ -9,17 +9,16 @@ import shop.kkeujeok.kkeujeokbackend.global.dto.PageInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
 import shop.kkeujeok.kkeujeokbackend.member.exception.MemberNotFoundException;
-import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request.FollowAcceptReqDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request.FollowReqDto;
-import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowAcceptResDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowInfoListDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowResDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.RecommendedFollowInfoListDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.RecommendedFollowInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
 import shop.kkeujeok.kkeujeokbackend.member.follow.domain.repository.FollowRepository;
 import shop.kkeujeok.kkeujeokbackend.member.follow.exception.FollowAlreadyExistsException;
 import shop.kkeujeok.kkeujeokbackend.member.follow.exception.FollowNotFoundException;
-import software.amazon.awssdk.services.s3.endpoints.internal.Value.Str;
 
 @Service
 @RequiredArgsConstructor
@@ -59,14 +58,24 @@ public class FollowService {
 
         Page<FollowInfoResDto> followInfoResDtos = followRepository.findFollowList(memberId, pageable);
 
-        return FollowInfoListDto.from(
+        return FollowInfoListDto.of(
                 followInfoResDtos.getContent(),
                 PageInfoResDto.from(followInfoResDtos)
         );
     }
 
+    public RecommendedFollowInfoListDto findRecommendedFollowList(String email, Pageable pageable) {
+        Long memberId = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new).getId();
+
+        Page<RecommendedFollowInfoResDto> recommendedFollowInfoResDtos =
+                followRepository.findRecommendedFollowList(memberId, pageable);
+
+        return RecommendedFollowInfoListDto.of(
+                recommendedFollowInfoResDtos.getContent(),
+                PageInfoResDto.from(recommendedFollowInfoResDtos)
+        );
+    }
 //    todo
-//     추천 친구 리스트 보는 로직
 //     친구 검색 기능 (email, 혹은 닉네임#고유번호로)
 //     친구 삭제 로직
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/application/FollowService.java
@@ -75,6 +75,17 @@ public class FollowService {
                 PageInfoResDto.from(recommendedFollowInfoResDtos)
         );
     }
+
+    @Transactional
+    public void delete(String email, Long memberId) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        Member toMemberEntity = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+
+        Follow follow = followRepository.findByFromMemberAndToMember(member, toMemberEntity)
+                .orElseThrow(FollowNotFoundException::new);
+
+        followRepository.delete(follow);
+    }
 //    todo
 //     친구 검색 기능 (email, 혹은 닉네임#고유번호로)
 //     친구 삭제 로직

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/Follow.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/Follow.java
@@ -1,9 +1,13 @@
 package shop.kkeujeok.kkeujeokbackend.member.follow.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import shop.kkeujeok.kkeujeokbackend.global.entity.BaseEntity;
@@ -11,7 +15,9 @@ import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Follow extends BaseEntity {
 
     @ManyToOne
@@ -21,4 +27,7 @@ public class Follow extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "to_member")
     private Member toMember;
+
+    @Enumerated(EnumType.STRING)
+    private FollowStatus followStatus;
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/Follow.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/Follow.java
@@ -1,0 +1,24 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import shop.kkeujeok.kkeujeokbackend.global.entity.BaseEntity;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow extends BaseEntity {
+
+    @ManyToOne
+    @JoinColumn(name = "from_member")
+    private Member fromMember;
+
+    @ManyToOne
+    @JoinColumn(name = "to_member")
+    private Member toMember;
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/FollowStatus.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/FollowStatus.java
@@ -1,0 +1,10 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.domain;
+
+public enum FollowStatus {
+
+    ACTIVE("활성화"),
+    UN_ACTIVE("비활성화");
+
+    FollowStatus(String description) {
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/FollowStatus.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/FollowStatus.java
@@ -2,8 +2,8 @@ package shop.kkeujeok.kkeujeokbackend.member.follow.domain;
 
 public enum FollowStatus {
 
-    ACTIVE("활성화"),
-    UN_ACTIVE("비활성화");
+    ACCEPT("수락"),
+    WAIT("대기");
 
     FollowStatus(String description) {
     }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepository.java
@@ -1,0 +1,8 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.domain.repository;
+
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+public interface FollowCustomRepository {
+
+    boolean existsByFromMemberAndToMember(Member fromMember, Member toMember);
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepository.java
@@ -6,5 +6,5 @@ public interface FollowCustomRepository {
 
     boolean existsByFromMemberAndToMember(Member fromMember, Member toMember);
 
-    boolean acceptFollowingRequest(Long followId);
+    void acceptFollowingRequest(Long followId);
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepository.java
@@ -1,10 +1,15 @@
 package shop.kkeujeok.kkeujeokbackend.member.follow.domain.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowInfoResDto;
 
 public interface FollowCustomRepository {
 
     boolean existsByFromMemberAndToMember(Member fromMember, Member toMember);
 
     void acceptFollowingRequest(Long followId);
+
+    Page<FollowInfoResDto> findFollowList(Long memberId, Pageable pageable);
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepository.java
@@ -5,4 +5,6 @@ import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 public interface FollowCustomRepository {
 
     boolean existsByFromMemberAndToMember(Member fromMember, Member toMember);
+
+    boolean acceptFollowingRequest(Long followId);
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepository.java
@@ -19,4 +19,6 @@ public interface FollowCustomRepository {
     Page<RecommendedFollowInfoResDto> findRecommendedFollowList(Long memberId, Pageable pageable);
 
     Optional<Follow> findByFromMemberAndToMember(Member fromMember, Member toMember);
+
+    Page<RecommendedFollowInfoResDto> searchRecommendedFollowUsingKeywords(Long memberId, String keyword, Pageable pageable);
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepository.java
@@ -1,10 +1,12 @@
 package shop.kkeujeok.kkeujeokbackend.member.follow.domain.repository;
 
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.RecommendedFollowInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
 
 public interface FollowCustomRepository {
 
@@ -15,4 +17,6 @@ public interface FollowCustomRepository {
     Page<FollowInfoResDto> findFollowList(Long memberId, Pageable pageable);
 
     Page<RecommendedFollowInfoResDto> findRecommendedFollowList(Long memberId, Pageable pageable);
+
+    Optional<Follow> findByFromMemberAndToMember(Member fromMember, Member toMember);
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.RecommendedFollowInfoResDto;
 
 public interface FollowCustomRepository {
 
@@ -12,4 +13,6 @@ public interface FollowCustomRepository {
     void acceptFollowingRequest(Long followId);
 
     Page<FollowInfoResDto> findFollowList(Long memberId, Pageable pageable);
+
+    Page<RecommendedFollowInfoResDto> findRecommendedFollowList(Long memberId, Pageable pageable);
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepositoryImpl.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.RecommendedFollowInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
 import shop.kkeujeok.kkeujeokbackend.member.follow.domain.FollowStatus;
 
 @Repository
@@ -125,5 +126,19 @@ public class FollowCustomRepositoryImpl implements FollowCustomRepository {
 
         return new PageImpl<>(pagedRecommendedFollows, pageable, recommendedFollows.size());
     }
+
+    @Override
+    public Optional<Follow> findByFromMemberAndToMember(Member fromMember, Member toMember) {
+        Follow followRecord = queryFactory
+                .selectFrom(follow)
+                .where(
+                        (follow.fromMember.eq(fromMember).and(follow.toMember.eq(toMember)))
+                                .or(follow.fromMember.eq(toMember).and(follow.toMember.eq(fromMember))) // 양방향 조회
+                )
+                .fetchOne();
+
+        return Optional.ofNullable(followRecord);
+    }
+
 
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepositoryImpl.java
@@ -35,12 +35,10 @@ public class FollowCustomRepositoryImpl implements FollowCustomRepository {
 
     @Override
     @Transactional
-    public boolean acceptFollowingRequest(Long followId) {
-        long updatedRows = new JPAUpdateClause(entityManager, follow)
+    public void acceptFollowingRequest(Long followId) {
+        new JPAUpdateClause(entityManager, follow)
                 .where(follow.id.eq(followId))
-                .set(follow.followStatus, FollowStatus.ACTIVE)
+                .set(follow.followStatus, FollowStatus.ACCEPT)
                 .execute();
-
-        return updatedRows > 0;
     }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepositoryImpl.java
@@ -1,0 +1,31 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.domain.repository;
+
+import static shop.kkeujeok.kkeujeokbackend.member.follow.domain.QFollow.follow;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FollowCustomRepositoryImpl implements FollowCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsByFromMemberAndToMember(Member fromMember, Member toMember) {
+        Integer fetchOne = queryFactory
+                .selectOne()
+                .from(follow)
+                .where((follow.fromMember.eq(fromMember)
+                        .and(follow.toMember.eq(toMember)))
+                        .or(follow.fromMember.eq(toMember)
+                                .and(follow.toMember.eq(fromMember))))
+                .fetchFirst();
+
+        return fetchOne != null;
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepositoryImpl.java
@@ -5,10 +5,17 @@ import static shop.kkeujeok.kkeujeokbackend.member.follow.domain.QFollow.follow;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.querydsl.jpa.impl.JPAUpdateClause;
 import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.member.follow.domain.FollowStatus;
 
 @Repository
@@ -40,5 +47,28 @@ public class FollowCustomRepositoryImpl implements FollowCustomRepository {
                 .where(follow.id.eq(followId))
                 .set(follow.followStatus, FollowStatus.ACCEPT)
                 .execute();
+    }
+
+    @Override
+    public Page<FollowInfoResDto> findFollowList(Long memberId, Pageable pageable) {
+        List<FollowInfoResDto> fetch = queryFactory
+                .selectFrom(follow)
+                .where(follow.fromMember.id.eq(memberId)
+                        .or(follow.toMember.id.eq(memberId)))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch()
+                .stream()
+                .map(follow -> FollowInfoResDto.from(follow, memberId))
+                .collect(Collectors.toList());
+
+        long total = Optional.ofNullable(queryFactory
+                .select(follow.count())
+                .from(follow)
+                .where(follow.fromMember.id.eq(memberId)
+                        .or(follow.toMember.id.eq(memberId)))
+                .fetchOne()).orElse(0L);
+
+        return new PageImpl<>(fetch, pageable, total);
     }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepositoryImpl.java
@@ -3,10 +3,13 @@ package shop.kkeujeok.kkeujeokbackend.member.follow.domain.repository;
 import static shop.kkeujeok.kkeujeokbackend.member.follow.domain.QFollow.follow;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.jpa.impl.JPAUpdateClause;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
+import shop.kkeujeok.kkeujeokbackend.member.follow.domain.FollowStatus;
 
 @Repository
 @RequiredArgsConstructor
@@ -14,6 +17,7 @@ import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 public class FollowCustomRepositoryImpl implements FollowCustomRepository {
 
     private final JPAQueryFactory queryFactory;
+    private final EntityManager entityManager;
 
     @Override
     public boolean existsByFromMemberAndToMember(Member fromMember, Member toMember) {
@@ -27,5 +31,16 @@ public class FollowCustomRepositoryImpl implements FollowCustomRepository {
                 .fetchFirst();
 
         return fetchOne != null;
+    }
+
+    @Override
+    @Transactional
+    public boolean acceptFollowingRequest(Long followId) {
+        long updatedRows = new JPAUpdateClause(entityManager, follow)
+                .where(follow.id.eq(followId))
+                .set(follow.followStatus, FollowStatus.ACTIVE)
+                .execute();
+
+        return updatedRows > 0;
     }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowRepository.java
@@ -3,5 +3,5 @@ package shop.kkeujeok.kkeujeokbackend.member.follow.domain.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
 
-public interface FollowRepository extends JpaRepository<Follow, Long> {
+public interface FollowRepository extends JpaRepository<Follow, Long>, FollowCustomRepository {
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowRepository.java
@@ -1,0 +1,7 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.kkeujeok.kkeujeokbackend.member.follow.domain.Follow;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/exception/FollowAlreadyExistsException.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/exception/FollowAlreadyExistsException.java
@@ -1,0 +1,13 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.exception;
+
+import shop.kkeujeok.kkeujeokbackend.global.error.exception.AccessDeniedGroupException;
+
+public class FollowAlreadyExistsException extends AccessDeniedGroupException {
+    public FollowAlreadyExistsException(String message) {
+        super(message);
+    }
+
+    public FollowAlreadyExistsException() {
+        this("이미 친구를 요청했습니다.");
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/exception/FollowNotFoundException.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/exception/FollowNotFoundException.java
@@ -1,0 +1,13 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.exception;
+
+import shop.kkeujeok.kkeujeokbackend.global.error.exception.NotFoundGroupException;
+
+public class FollowNotFoundException extends NotFoundGroupException {
+    public FollowNotFoundException(String message) {
+        super(message);
+    }
+
+    public FollowNotFoundException() {
+        this("존재하지 않는 팔로워(회원)입니다");
+    }
+}

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/common/annotation/ControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/common/annotation/ControllerTest.java
@@ -23,6 +23,7 @@ import shop.kkeujeok.kkeujeokbackend.dashboard.team.application.TeamDashboardSer
 import shop.kkeujeok.kkeujeokbackend.global.aws.S3Service;
 import shop.kkeujeok.kkeujeokbackend.global.jwt.TokenProvider;
 import shop.kkeujeok.kkeujeokbackend.member.api.MemberControllerTest;
+import shop.kkeujeok.kkeujeokbackend.member.follow.application.FollowService;
 import shop.kkeujeok.kkeujeokbackend.member.mypage.application.MyPageService;
 import shop.kkeujeok.kkeujeokbackend.member.nickname.application.NicknameService;
 import shop.kkeujeok.kkeujeokbackend.notification.api.NotificationController;
@@ -88,4 +89,7 @@ public abstract class ControllerTest {
 
     @MockBean
     S3Service s3Service;
+
+    @MockBean
+    protected FollowService followService;
 }

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/member/follow/api/FollowControllerTest.java
@@ -1,0 +1,274 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static shop.kkeujeok.kkeujeokbackend.global.restdocs.RestDocsHandler.requestFields;
+import static shop.kkeujeok.kkeujeokbackend.global.restdocs.RestDocsHandler.responseFields;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import shop.kkeujeok.kkeujeokbackend.auth.api.dto.request.TokenReqDto;
+import shop.kkeujeok.kkeujeokbackend.common.annotation.ControllerTest;
+import shop.kkeujeok.kkeujeokbackend.global.annotationresolver.CurrentUserEmailArgumentResolver;
+import shop.kkeujeok.kkeujeokbackend.global.dto.PageInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.global.error.ControllerAdvice;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.request.FollowReqDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowResDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowInfoListDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.RecommendedFollowInfoListDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.FollowInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.member.follow.api.dto.response.RecommendedFollowInfoResDto;
+
+import java.util.Collections;
+
+class FollowControllerTest extends ControllerTest {
+
+    @InjectMocks
+    private FollowController followController;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        MockitoAnnotations.openMocks(this);
+
+        followController = new FollowController(followService);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(followController)
+                .apply(documentationConfiguration(restDocumentation))
+                .setCustomArgumentResolvers(new CurrentUserEmailArgumentResolver(tokenProvider))
+                .setControllerAdvice(new ControllerAdvice())
+                .build();
+
+        when(tokenProvider.getUserEmailFromToken(any(TokenReqDto.class))).thenReturn("email");
+    }
+
+    @DisplayName("POST 친구 추가 요청")
+    @Test
+    void 친구_추가_요청() throws Exception {
+        FollowReqDto request = new FollowReqDto(2L);
+        FollowResDto response = new FollowResDto(2L);
+        given(followService.save(anyString(), any(FollowReqDto.class))).willReturn(response);
+
+        mockMvc.perform(post("/api/member/follow")
+                        .header("Authorization", "Bearer valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andDo(document("follow/save",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("memberId").description("친구 추가 대상의 멤버 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.toMemberId").description("친구로 추가된 멤버 ID")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("POST 친구 요청 수락")
+    @Test
+    void 친구_요청_수락() throws Exception {
+        doNothing().when(followService).accept(anyLong());
+
+        mockMvc.perform(post("/api/member/follow/accept/{followId}", 1L)
+                        .header("Authorization", "Bearer valid-token"))
+                .andDo(print())
+                .andDo(document("follow/accept",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("followId").description("친구 요청 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data").optional().description("응답 데이터. 친구 추가 수락의 경우 null 반환")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("GET 내 친구 목록 조회")
+    @Test
+    void 친구_목록_조회() throws Exception {
+        FollowInfoListDto response = new FollowInfoListDto(
+                Collections.singletonList(new FollowInfoResDto(1L, "nickname", "name", "profileImage")),
+                new PageInfoResDto(0, 10, 1)
+        );
+        given(followService.findFollowList(anyString(), any())).willReturn(response);
+
+        mockMvc.perform(get("/api/member/follow")
+                        .header("Authorization", "Bearer valid-token")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andDo(print())
+                .andDo(document("follow/findFollowList",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호"),
+                                parameterWithName("size").description("페이지 크기")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.followInfoResDto[].memberId").description("친구 멤버 ID"),
+                                fieldWithPath("data.followInfoResDto[].nickname").description("친구 닉네임"),
+                                fieldWithPath("data.followInfoResDto[].name").description("친구 이름"),
+                                fieldWithPath("data.followInfoResDto[].profileImage").description("친구 프로필 이미지"),
+                                fieldWithPath("data.pageInfoResDto.currentPage").description("현재 페이지 번호"),
+                                fieldWithPath("data.pageInfoResDto.totalPages").description("전체 페이지 수"),
+                                fieldWithPath("data.pageInfoResDto.totalItems").description("전체 항목 수")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("GET 추천 친구 목록 조회")
+    @Test
+    void 추천_친구_목록_조회() throws Exception {
+        RecommendedFollowInfoListDto response = new RecommendedFollowInfoListDto(
+                Collections.singletonList(new RecommendedFollowInfoResDto(2L, "nickname2", "name2", "profileImage2")),
+                new PageInfoResDto(0, 10, 1)
+        );
+        given(followService.findRecommendedFollowList(anyString(), any())).willReturn(response);
+
+        mockMvc.perform(get("/api/member/follow/recommended")
+                        .header("Authorization", "Bearer valid-token")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andDo(print())
+                .andDo(document("follow/findRecommendedFollowList",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호"),
+                                parameterWithName("size").description("페이지 크기")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.recommendedFollowInfoResDtos[].memberId").description(
+                                        "추천 친구 멤버 ID"),
+                                fieldWithPath("data.recommendedFollowInfoResDtos[].nickname").description("추천 친구 닉네임"),
+                                fieldWithPath("data.recommendedFollowInfoResDtos[].name").description("추천 친구 이름"),
+                                fieldWithPath("data.recommendedFollowInfoResDtos[].profileImage").description(
+                                        "추천 친구 프로필 이미지"),
+                                fieldWithPath("data.pageInfoResDto.currentPage").description("현재 페이지 번호"),
+                                fieldWithPath("data.pageInfoResDto.totalPages").description("전체 페이지 수"),
+                                fieldWithPath("data.pageInfoResDto.totalItems").description("전체 항목 수")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("DELETE 친구 삭제")
+    @Test
+    void 친구_삭제() throws Exception {
+        doNothing().when(followService).delete(anyString(), anyLong());
+
+        mockMvc.perform(delete("/api/member/follow/{memberId}", 1L)
+                        .header("Authorization", "Bearer valid-token"))
+                .andDo(print())
+                .andDo(document("follow/delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("memberId").description("친구 관계를 해제할 멤버 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data").optional().description("응답 데이터. 친구 추가 수락의 경우 null 반환")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("GET 키워드로 추천 친구 목록 조회")
+    @Test
+    void 키워드로_추천_친구_목록_조회() throws Exception {
+        RecommendedFollowInfoListDto response = new RecommendedFollowInfoListDto(
+                Collections.singletonList(new RecommendedFollowInfoResDto(3L, "nickname3", "name3", "profileImage3")),
+                new PageInfoResDto(0, 10, 1)
+        );
+        given(followService.searchRecommendedFollowUsingKeywords(anyString(), anyString(), any())).willReturn(response);
+
+        mockMvc.perform(get("/api/member/follow/search")
+                        .header("Authorization", "Bearer valid-token")
+                        .param("keyword", "test")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andDo(print())
+                .andDo(document("follow/searchRecommendedFollowUsingKeywords",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        queryParameters(
+                                parameterWithName("keyword").description("검색 키워드"),
+                                parameterWithName("page").description("페이지 번호"),
+                                parameterWithName("size").description("페이지 크기")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.recommendedFollowInfoResDtos[].memberId").description(
+                                        "추천 친구 멤버 ID"),
+                                fieldWithPath("data.recommendedFollowInfoResDtos[].nickname").description("추천 친구 닉네임"),
+                                fieldWithPath("data.recommendedFollowInfoResDtos[].name").description("추천 친구 이름"),
+                                fieldWithPath("data.recommendedFollowInfoResDtos[].profileImage").description(
+                                        "추천 친구 프로필 이미지"),
+                                fieldWithPath("data.pageInfoResDto.currentPage").description("현재 페이지 번호"),
+                                fieldWithPath("data.pageInfoResDto.totalPages").description("전체 페이지 수"),
+                                fieldWithPath("data.pageInfoResDto.totalItems").description("전체 항목 수")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #197 

## 📝작업 내용

> 친구 추가 요청
> 친구 추가 요청 수락
> 내 친구 목록 조회
> 추천 친구 목록 조회
> 친구 삭제
> 친구 검색
## 💬리뷰 요구사항(선택)

> 알맞게 구현하고 있는지 알려주세요!

> 친구 추가 수락했을 때 response를 무엇을 하는 게 가장 좋을까요? 또 request는 무엇이 좋을까요?

> delete할 때 followId로만 삭제할 수 있게 할지, 지금처럼 두 멤버 정보를 통해 삭제를 할지 고민입니다. 무엇이 더 맞는 로직일까요?
저는 소셜 네트워크에서 사용자가 친구 관계를 끊는 등의 작업에서는 fromMember와 toMember를 사용하여 관계를 삭제하는 것이 더 자연스다고 생각했습니다.

> 또 이번 삭제는 delete 삭제를 사용했는데요. 삭제했을 때 데이터베이스에서 딱히 친구 관계 데이터를 저장하고 있을 필요가 없다고 판단했기 때문에 이렇게 구현해보았습니다.

> 추천 친구 api는 만들긴 했는데, 필요 없을 것 같습니다.  키워드로 검색하기에 공백 넣으면 되도록 마지막에 검색 api 구현해서..
