### PR TITLE
Refactor(#197): 친구 수락 중복시 에러처리, 친구 검색 이름으로도 가능하게, 친구 마이페이지 조회 api 구현

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -38,3 +38,14 @@ include::{snippets}/member/mypage-update/request-fields.adoc[]
 
 include::{snippets}/member/mypage/http-response.adoc[]
 include::{snippets}/member/mypage/response-fields.adoc[]
+
+=== 친구 프로필 정보 조회 API
+
+==== 요청
+
+include::{snippets}/member/friend-profile/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/member/friend-profile/http-response.adoc[]
+include::{snippets}/member/friend-profile/response-fields.adoc[]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -49,3 +49,15 @@ include::{snippets}/member/friend-profile/http-request.adoc[]
 
 include::{snippets}/member/friend-profile/http-response.adoc[]
 include::{snippets}/member/friend-profile/response-fields.adoc[]
+
+=== 친구 public 개인 대시보드와 챌린지 정보 조회 API
+
+==== 요청
+
+include::{snippets}/member/friend-dashboard-challenges/http-request.adoc[]
+include::{snippets}/member/friend-dashboard-challenges/query-parameters.adoc[]
+
+==== 응답
+
+include::{snippets}/member/friend-dashboard-challenges/http-response.adoc[]
+include::{snippets}/member/friend-dashboard-challenges/response-fields.adoc[]

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/api/MemberController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/api/MemberController.java
@@ -8,6 +8,7 @@ import shop.kkeujeok.kkeujeokbackend.global.annotation.CurrentUserEmail;
 import shop.kkeujeok.kkeujeokbackend.global.template.RspTemplate;
 import shop.kkeujeok.kkeujeokbackend.member.mypage.api.dto.request.MyPageUpdateReqDto;
 import shop.kkeujeok.kkeujeokbackend.member.mypage.api.dto.response.MyPageInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.member.mypage.api.dto.response.PersonalDashboardsAndChallengesResDto;
 import shop.kkeujeok.kkeujeokbackend.member.mypage.api.dto.response.TeamDashboardsAndChallengesResDto;
 import shop.kkeujeok.kkeujeokbackend.member.mypage.application.MyPageService;
 
@@ -35,7 +36,8 @@ public class MemberController {
                                                                                          @RequestParam(name = "requestEmail") String requestEmail,
                                                                                          @RequestParam(name = "page", defaultValue = "0") int page,
                                                                                          @RequestParam(name = "size", defaultValue = "10") int size) {
-        TeamDashboardsAndChallengesResDto response = myPageService.findTeamDashboardsAndChallenges(email, requestEmail, PageRequest.of(page, size));
+        TeamDashboardsAndChallengesResDto response = myPageService.findTeamDashboardsAndChallenges(email, requestEmail,
+                PageRequest.of(page, size));
         return new RspTemplate<>(HttpStatus.OK, "대시보드와 챌린지 정보 조회", response);
     }
 
@@ -43,5 +45,14 @@ public class MemberController {
     public RspTemplate<MyPageInfoResDto> getFriendProfileInfo(@PathVariable Long memberId) {
         MyPageInfoResDto friendProfile = myPageService.findFriendProfile(memberId);
         return new RspTemplate<>(HttpStatus.OK, "친구 프로필 정보 조회", friendProfile);
+    }
+
+    @GetMapping("/mypage/{memberId}/dashboard-challenges")
+    public RspTemplate<PersonalDashboardsAndChallengesResDto> getPersonalDashboardsAndChallenges(@PathVariable Long memberId,
+                                                                                                 @RequestParam(name = "page", defaultValue = "0") int page,
+                                                                                                 @RequestParam(name = "size", defaultValue = "10") int size) {
+        PersonalDashboardsAndChallengesResDto response = myPageService.findFriendDashboardsAndChallenges(memberId,
+                PageRequest.of(page, size));
+        return new RspTemplate<>(HttpStatus.OK, "대시보드와 챌린지 정보 조회", response);
     }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/api/MemberController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/api/MemberController.java
@@ -38,4 +38,10 @@ public class MemberController {
         TeamDashboardsAndChallengesResDto response = myPageService.findTeamDashboardsAndChallenges(email, requestEmail, PageRequest.of(page, size));
         return new RspTemplate<>(HttpStatus.OK, "대시보드와 챌린지 정보 조회", response);
     }
+
+    @GetMapping("/mypage/{memberId}")
+    public RspTemplate<MyPageInfoResDto> getFriendProfileInfo(@PathVariable Long memberId) {
+        MyPageInfoResDto friendProfile = myPageService.findFriendProfile(memberId);
+        return new RspTemplate<>(HttpStatus.OK, "친구 프로필 정보 조회", friendProfile);
+    }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/api/MemberController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/api/MemberController.java
@@ -41,17 +41,17 @@ public class MemberController {
         return new RspTemplate<>(HttpStatus.OK, "대시보드와 챌린지 정보 조회", response);
     }
 
-    @GetMapping("/mypage/{memberId}")
-    public RspTemplate<MyPageInfoResDto> getFriendProfileInfo(@PathVariable Long memberId) {
-        MyPageInfoResDto friendProfile = myPageService.findFriendProfile(memberId);
+    @GetMapping("/mypage/{friendId}")
+    public RspTemplate<MyPageInfoResDto> getFriendProfileInfo(@PathVariable Long friendId) {
+        MyPageInfoResDto friendProfile = myPageService.findFriendProfile(friendId);
         return new RspTemplate<>(HttpStatus.OK, "친구 프로필 정보 조회", friendProfile);
     }
 
-    @GetMapping("/mypage/{memberId}/dashboard-challenges")
-    public RspTemplate<PersonalDashboardsAndChallengesResDto> getPersonalDashboardsAndChallenges(@PathVariable Long memberId,
+    @GetMapping("/mypage/{friendId}/dashboard-challenges")
+    public RspTemplate<PersonalDashboardsAndChallengesResDto> getPersonalDashboardsAndChallenges(@PathVariable Long friendId,
                                                                                                  @RequestParam(name = "page", defaultValue = "0") int page,
                                                                                                  @RequestParam(name = "size", defaultValue = "10") int size) {
-        PersonalDashboardsAndChallengesResDto response = myPageService.findFriendDashboardsAndChallenges(memberId,
+        PersonalDashboardsAndChallengesResDto response = myPageService.findFriendDashboardsAndChallenges(friendId,
                 PageRequest.of(page, size));
         return new RspTemplate<>(HttpStatus.OK, "대시보드와 챌린지 정보 조회", response);
     }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepositoryImpl.java
@@ -175,11 +175,8 @@ public class FollowCustomRepositoryImpl implements FollowCustomRepository {
     }
 
     @Override
-    public Page<MemberInfoForFollowResDto> searchFollowListUsingKeywords(Long memberId, String keyword,
-                                                                         Pageable pageable) {
-        BooleanExpression keywordCondition = keyword != null && !keyword.isBlank()
-                ? member.name.containsIgnoreCase(keyword).or(member.email.containsIgnoreCase(keyword))
-                : null;
+    public Page<MemberInfoForFollowResDto> searchFollowListUsingKeywords(Long memberId, String keyword, Pageable pageable) {
+        BooleanExpression keywordCondition = buildKeywordCondition(keyword);
 
         List<MemberInfoForFollowResDto> members = queryFactory
                 .select(Projections.constructor(MemberInfoForFollowResDto.class,
@@ -215,6 +212,14 @@ public class FollowCustomRepositoryImpl implements FollowCustomRepository {
         return new PageImpl<>(members, pageable, total);
     }
 
+    private BooleanExpression buildKeywordCondition(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return null;
+        }
+        return member.name.containsIgnoreCase(keyword).or(member.email.containsIgnoreCase(keyword));
+    }
+
+
     @Override
     public MyFollowsResDto findMyFollowsCount(Long memberId) {
         int followCount = (int) queryFactory
@@ -229,5 +234,4 @@ public class FollowCustomRepositoryImpl implements FollowCustomRepository {
 
         return MyFollowsResDto.from(followCount);
     }
-
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/domain/repository/FollowCustomRepositoryImpl.java
@@ -73,7 +73,6 @@ public class FollowCustomRepositoryImpl implements FollowCustomRepository {
         }
     }
 
-
     @Override
     public Page<FollowInfoResDto> findFollowList(Long memberId, Pageable pageable) {
         List<FollowInfoResDto> fetch = queryFactory
@@ -145,7 +144,8 @@ public class FollowCustomRepositoryImpl implements FollowCustomRepository {
                             .from(follow)
                             .where(
                                     (follow.fromMember.id.eq(memberId).and(follow.toMember.id.eq(teamMember.getId())))
-                                            .or(follow.fromMember.id.eq(teamMember.getId()).and(follow.toMember.id.eq(memberId)))
+                                            .or(follow.fromMember.id.eq(teamMember.getId())
+                                                    .and(follow.toMember.id.eq(memberId)))
                             )
                             .fetchFirst() != null;
 
@@ -159,7 +159,6 @@ public class FollowCustomRepositoryImpl implements FollowCustomRepository {
 
         return new PageImpl<>(pagedRecommendedFollows, pageable, recommendedFollows.size());
     }
-
 
     @Override
     public Optional<Follow> findByFromMemberAndToMember(Member fromMember, Member toMember) {
@@ -175,7 +174,8 @@ public class FollowCustomRepositoryImpl implements FollowCustomRepository {
     }
 
     @Override
-    public Page<MemberInfoForFollowResDto> searchFollowListUsingKeywords(Long memberId, String keyword, Pageable pageable) {
+    public Page<MemberInfoForFollowResDto> searchFollowListUsingKeywords(Long memberId, String keyword,
+                                                                         Pageable pageable) {
         BooleanExpression keywordCondition = buildKeywordCondition(keyword);
 
         List<MemberInfoForFollowResDto> members = queryFactory
@@ -218,7 +218,6 @@ public class FollowCustomRepositoryImpl implements FollowCustomRepository {
         }
         return member.name.containsIgnoreCase(keyword).or(member.email.containsIgnoreCase(keyword));
     }
-
 
     @Override
     public MyFollowsResDto findMyFollowsCount(Long memberId) {

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/exception/FollowAlreadyAcceptException.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/follow/exception/FollowAlreadyAcceptException.java
@@ -1,0 +1,13 @@
+package shop.kkeujeok.kkeujeokbackend.member.follow.exception;
+
+import shop.kkeujeok.kkeujeokbackend.global.error.exception.AccessDeniedGroupException;
+
+public class FollowAlreadyAcceptException extends AccessDeniedGroupException {
+    public FollowAlreadyAcceptException(String message) {
+        super(message);
+    }
+
+    public FollowAlreadyAcceptException() {
+        this("이미 친구를 요청을 수락한 상태입니다.");
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/mypage/api/dto/response/PersonalDashboardsAndChallengesResDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/mypage/api/dto/response/PersonalDashboardsAndChallengesResDto.java
@@ -1,0 +1,18 @@
+package shop.kkeujeok.kkeujeokbackend.member.mypage.api.dto.response;
+
+import shop.kkeujeok.kkeujeokbackend.challenge.api.dto.response.ChallengeListResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.response.PersonalDashboardPageListResDto;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboardListResDto;
+
+public record PersonalDashboardsAndChallengesResDto(
+        PersonalDashboardPageListResDto personalDashboardList,
+        ChallengeListResDto challengeList
+) {
+    public static PersonalDashboardsAndChallengesResDto of(PersonalDashboardPageListResDto personalDashboardList,
+                                                           ChallengeListResDto challengeList) {
+        return new PersonalDashboardsAndChallengesResDto(
+                personalDashboardList,
+                challengeList
+        );
+    }
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/mypage/application/MyPageService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/mypage/application/MyPageService.java
@@ -13,8 +13,10 @@ import shop.kkeujeok.kkeujeokbackend.dashboard.team.api.dto.response.TeamDashboa
 import shop.kkeujeok.kkeujeokbackend.dashboard.team.application.TeamDashboardService;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
+import shop.kkeujeok.kkeujeokbackend.member.exception.MemberNotFoundException;
 import shop.kkeujeok.kkeujeokbackend.member.mypage.api.dto.request.MyPageUpdateReqDto;
 import shop.kkeujeok.kkeujeokbackend.member.mypage.api.dto.response.MyPageInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.member.mypage.api.dto.response.PersonalDashboardsAndChallengesResDto;
 import shop.kkeujeok.kkeujeokbackend.member.mypage.api.dto.response.TeamDashboardsAndChallengesResDto;
 import shop.kkeujeok.kkeujeokbackend.member.mypage.exception.ExistsNicknameException;
 
@@ -30,7 +32,7 @@ public class MyPageService {
 
     // 프로필 정보 조회
     public MyPageInfoResDto findMyProfileByEmail(String email) {
-        Member member = memberRepository.findByEmail(email).orElseThrow();
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
 
         return MyPageInfoResDto.From(member);
     }
@@ -83,10 +85,20 @@ public class MyPageService {
 
     // 친구 프로필 정보 조회
     public MyPageInfoResDto findFriendProfile(Long memberId) {
-        Member member = memberRepository.findById(memberId).orElseThrow();
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
         return MyPageInfoResDto.From(member);
     }
 
-    // todo: 친구 프로필에 표시되는 정보를 추가해야 함
+    // 친구 프로필에 표시되는 정보 조회
+    public PersonalDashboardsAndChallengesResDto findFriendDashboardsAndChallenges(Long memberId, Pageable pageable) {
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+
+        ChallengeListResDto challengeListResDto = challengeService.findChallengeForMemberId(member.getEmail(), pageable);
+
+        PersonalDashboardPageListResDto personalDashboardPageListResDto =
+                personalDashboardService.findPublicPersonalDashboards(member.getEmail(), pageable);
+
+        return PersonalDashboardsAndChallengesResDto.of(personalDashboardPageListResDto, challengeListResDto);
+    }
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/mypage/application/MyPageService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/mypage/application/MyPageService.java
@@ -80,4 +80,13 @@ public class MyPageService {
     private String normalizeNickname(String nickname) {
         return nickname.replaceAll("\\s+", "");
     }
+
+    // 친구 프로필 정보 조회
+    public MyPageInfoResDto findFriendProfile(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+
+        return MyPageInfoResDto.From(member);
+    }
+
+    // todo: 친구 프로필에 표시되는 정보를 추가해야 함
 }

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/member/api/MemberControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/member/api/MemberControllerTest.java
@@ -211,4 +211,48 @@ public class MemberControllerTest extends ControllerTest {
 //                ))
 //                .andExpect(status().isOk());
 //    }
+
+    @DisplayName("친구의 프로필 정보를 가져옵니다.")
+    @Test
+    void 친구_프로필_정보를_가져옵니다() throws Exception {
+        // Given
+        Long friendId = 1L;
+        MyPageInfoResDto friendProfileDto = new MyPageInfoResDto(
+                "friendPicture",
+                "friend@example.com",
+                "친구이름",
+                "친구닉네임",
+                SocialType.GOOGLE,
+                "친구소개"
+        );
+
+        when(myPageService.findFriendProfile(friendId)).thenReturn(friendProfileDto);
+
+        // When & Then
+        mockMvc.perform(get("/api/members/mypage/{memberId}", friendId)
+                        .header("Authorization", "Bearer valid-token"))
+                .andDo(print())
+                .andDo(document("member/friend-profile",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("statusCode").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.picture").description("친구 사진"),
+                                fieldWithPath("data.email").description("친구 이메일"),
+                                fieldWithPath("data.name").description("친구 이름"),
+                                fieldWithPath("data.nickName").description("친구 닉네임"),
+                                fieldWithPath("data.socialType").description("친구 소셜 타입"),
+                                fieldWithPath("data.introduction").description("친구 소개")
+                        )
+                ))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("친구 프로필 정보 조회")))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.email", is("friend@example.com")))
+                .andExpect(jsonPath("$.data.name", is("친구이름")))
+                .andExpect(jsonPath("$.data.nickName", is("친구닉네임")))
+                .andExpect(jsonPath("$.data.socialType", is(SocialType.GOOGLE.name())))
+                .andExpect(jsonPath("$.data.introduction", is("친구소개")));
+    }
 }

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/member/api/MemberControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/member/api/MemberControllerTest.java
@@ -20,6 +20,7 @@ import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Role;
 import shop.kkeujeok.kkeujeokbackend.member.domain.SocialType;
 import shop.kkeujeok.kkeujeokbackend.member.mypage.api.dto.response.MyPageInfoResDto;
+import shop.kkeujeok.kkeujeokbackend.member.mypage.api.dto.response.PersonalDashboardsAndChallengesResDto;
 import shop.kkeujeok.kkeujeokbackend.member.mypage.api.dto.response.TeamDashboardsAndChallengesResDto;
 
 import java.util.ArrayList;
@@ -255,4 +256,69 @@ public class MemberControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.data.socialType", is(SocialType.GOOGLE.name())))
                 .andExpect(jsonPath("$.data.introduction", is("친구소개")));
     }
+
+    @DisplayName("친구의 public 개인 대시보드와 챌린지 정보를 가져옵니다.")
+    @Test
+    void 친구_대시보드와_챌린지_정보를_가져옵니다() throws Exception {
+        // Given
+        PersonalDashboardPageListResDto personalDashboardList = new PersonalDashboardPageListResDto(
+                new ArrayList<>(),
+                new PageInfoResDto(0, 0, 0)
+        );
+
+        ChallengeListResDto challengeList = new ChallengeListResDto(
+                new ArrayList<>(),
+                new PageInfoResDto(0, 0, 0)
+        );
+
+        PersonalDashboardsAndChallengesResDto resDto = new PersonalDashboardsAndChallengesResDto(
+                personalDashboardList,
+                challengeList
+        );
+
+        Long friendId = 1L;
+
+        when(myPageService.findFriendDashboardsAndChallenges(friendId, PageRequest.of(0, 10))).thenReturn(resDto);
+
+        // When & Then
+        mockMvc.perform(get("/api/members/mypage/{memberId}/dashboard-challenges", friendId)
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andDo(print())
+                .andDo(document("member/friend-dashboard-challenges",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (기본값: 0)"),
+                                parameterWithName("size").description("페이지 당 항목 수 (기본값: 10)")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.personalDashboardList.personalDashboardInfoResDto").description("개인 대시보드 정보 목록"),
+                                fieldWithPath("data.personalDashboardList.pageInfoResDto.currentPage").description("현재 페이지 번호"),
+                                fieldWithPath("data.personalDashboardList.pageInfoResDto.totalPages").description("총 페이지 수"),
+                                fieldWithPath("data.personalDashboardList.pageInfoResDto.totalItems").description("총 항목 수"),
+                                fieldWithPath("data.challengeList.challengeInfoResDto").description("챌린지 정보 목록"),
+                                fieldWithPath("data.challengeList.pageInfoResDto.currentPage").description("현재 페이지 번호"),
+                                fieldWithPath("data.challengeList.pageInfoResDto.totalPages").description("총 페이지 수"),
+                                fieldWithPath("data.challengeList.pageInfoResDto.totalItems").description("총 항목 수")
+                        )
+                ))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode", is(200)))
+                .andExpect(jsonPath("$.message", is("대시보드와 챌린지 정보 조회")))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.personalDashboardList").exists())
+                .andExpect(jsonPath("$.data.personalDashboardList.personalDashboardInfoResDto").isArray())
+                .andExpect(jsonPath("$.data.personalDashboardList.pageInfoResDto.currentPage", is(0)))
+                .andExpect(jsonPath("$.data.personalDashboardList.pageInfoResDto.totalPages", is(0)))
+                .andExpect(jsonPath("$.data.personalDashboardList.pageInfoResDto.totalItems", is(0)))
+                .andExpect(jsonPath("$.data.challengeList").exists())
+                .andExpect(jsonPath("$.data.challengeList.challengeInfoResDto").isArray())
+                .andExpect(jsonPath("$.data.challengeList.pageInfoResDto.currentPage", is(0)))
+                .andExpect(jsonPath("$.data.challengeList.pageInfoResDto.totalPages", is(0)))
+                .andExpect(jsonPath("$.data.challengeList.pageInfoResDto.totalItems", is(0)));
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #197 

## 📝작업 내용

> 친구 수락 중복시 에러처리, 친구 검색 이름으로도 가능하게, 친구 마이페이지 조회 api 구현