### PR TITLE
Refactor(#197): 개인 대시보드 상세 조회 예외 검증 수정, 블록 권한 제어, 휴지통 전체 삭제 기능 추가, 삭제된 블록 30일 이후 영구 삭제 기능 추가

### DIFF
--- a/src/docs/asciidoc/block.adoc
+++ b/src/docs/asciidoc/block.adoc
@@ -117,3 +117,14 @@ include::{snippets}/block/deletePermanentBlock/path-parameters.adoc[]
 ==== 응답
 
 include::{snippets}/block/deletePermanentBlock/http-response.adoc[]
+
+=== 삭제된 블록 영구 삭제 (휴지통 비움)
+
+==== 요청
+
+include::{snippets}/block/deleteAllPermanentBlock/http-request.adoc[]
+include::{snippets}/block/deleteAllPermanentBlock/query-parameters.adoc[]
+
+==== 응답
+
+include::{snippets}/block/deleteAllPermanentBlock/http-response.adoc[]

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockController.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockController.java
@@ -98,4 +98,12 @@ public class BlockController {
                 "블록 영구 삭제");
     }
 
+    @DeleteMapping("/permanent")
+    public RspTemplate<Void> deleteAllPermanently(@CurrentUserEmail String email,
+                                                  @RequestParam(name = "dashboardId") Long dashboardId) {
+        blockService.deleteAllPermanently(email, dashboardId);
+        return new RspTemplate<>(HttpStatus.OK,
+                "삭제된 블록 영구 삭제(휴지통 비움)");
+    }
+
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
@@ -244,7 +244,9 @@ public class BlockService {
     private void validateDashboardAccess(Dashboard dashboard, Member member) {
         if (dashboard instanceof PersonalDashboard) {
             validatePersonalDashboardAccess((PersonalDashboard) dashboard, member);
-        } else {
+        }
+
+        if (dashboard instanceof TeamDashboard) {
             validateTeamDashboardAccess((TeamDashboard) dashboard, member);
         }
     }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
@@ -28,6 +28,9 @@ import shop.kkeujeok.kkeujeokbackend.challenge.domain.Challenge;
 import shop.kkeujeok.kkeujeokbackend.dashboard.domain.Dashboard;
 import shop.kkeujeok.kkeujeokbackend.dashboard.domain.repository.DashboardRepository;
 import shop.kkeujeok.kkeujeokbackend.dashboard.exception.DashboardNotFoundException;
+import shop.kkeujeok.kkeujeokbackend.dashboard.exception.UnauthorizedAccessException;
+import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard;
+import shop.kkeujeok.kkeujeokbackend.dashboard.team.domain.TeamDashboard;
 import shop.kkeujeok.kkeujeokbackend.global.dto.PageInfoResDto;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
@@ -49,6 +52,8 @@ public class BlockService {
         Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Dashboard dashboard = dashboardRepository.findById(blockSaveReqDto.dashboardId())
                 .orElseThrow(DashboardNotFoundException::new);
+
+        validateDashboardAccess(dashboard, member);
 
         int lastSequence = blockRepository.findLastSequenceByProgress(
                 member,
@@ -81,6 +86,10 @@ public class BlockService {
     public BlockInfoResDto update(String email, Long blockId, BlockUpdateReqDto blockUpdateReqDto) {
         Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Block block = blockRepository.findById(blockId).orElseThrow(BlockNotFoundException::new);
+        Dashboard dashboard = dashboardRepository.findById(block.getDashboard().getId())
+                .orElseThrow(DashboardNotFoundException::new);
+
+        validateDashboardAccess(dashboard, member);
 
         block.update(blockUpdateReqDto.title(),
                 blockUpdateReqDto.contents(),
@@ -97,6 +106,11 @@ public class BlockService {
         Block block = blockRepository.findById(blockId).orElseThrow(BlockNotFoundException::new);
 
         Progress progress = parseProgress(progressString);
+
+        Dashboard dashboard = dashboardRepository.findById(block.getDashboard().getId())
+                .orElseThrow(DashboardNotFoundException::new);
+
+        validateDashboardAccess(dashboard, member);
 
         block.progressUpdate(progress);
 
@@ -137,6 +151,10 @@ public class BlockService {
     public void delete(String email, Long blockId) {
         Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Block block = blockRepository.findById(blockId).orElseThrow(BlockNotFoundException::new);
+        Dashboard dashboard = dashboardRepository.findById(block.getDashboard().getId())
+                .orElseThrow(DashboardNotFoundException::new);
+
+        validateDashboardAccess(dashboard, member);
 
         block.statusUpdate();
     }
@@ -146,6 +164,10 @@ public class BlockService {
     public void changeBlocksSequence(String email, BlockSequenceUpdateReqDto blockSequenceUpdateReqDto) {
         Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Long dashboardId = blockSequenceUpdateReqDto.dashboardId();
+        Dashboard dashboard = dashboardRepository.findById(blockSequenceUpdateReqDto.dashboardId())
+                .orElseThrow(DashboardNotFoundException::new);
+
+        validateDashboardAccess(dashboard, member);
 
         updateBlockSequence(member, blockSequenceUpdateReqDto.notStartedList(), dashboardId, Progress.NOT_STARTED);
         updateBlockSequence(member, blockSequenceUpdateReqDto.inProgressList(), dashboardId, Progress.IN_PROGRESS);
@@ -170,8 +192,13 @@ public class BlockService {
     }
 
     // 삭제된 블록 조회
+    @Transactional
     public BlockListResDto findDeletedBlocks(String email, Long dashboardId, Pageable pageable) {
         Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        Dashboard dashboard = dashboardRepository.findById(dashboardId).orElseThrow(DashboardNotFoundException::new);
+
+        validateDashboardAccess(dashboard, member);
+
         Page<Block> deletedBlocks = blockRepository.findByDeletedBlocks(dashboardId, pageable);
 
         List<BlockInfoResDto> blockInfoResDtoList = deletedBlocks.stream()
@@ -186,8 +213,25 @@ public class BlockService {
     public void deletePermanently(String email, Long blockId) {
         Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Block block = blockRepository.findById(blockId).orElseThrow(BlockNotFoundException::new);
+        Dashboard dashboard = dashboardRepository.findById(block.getDashboard().getId())
+                .orElseThrow(DashboardNotFoundException::new);
+
+        validateDashboardAccess(dashboard, member);
 
         blockRepository.delete(block);
+    }
+
+    // 삭제된 블록 전체 삭제
+    @Transactional
+    public void deleteAllPermanently(String email, Long dashboardId) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        Dashboard dashboard = dashboardRepository.findById(dashboardId).orElseThrow(DashboardNotFoundException::new);
+
+        validateDashboardAccess(dashboard, member);
+
+        List<Block> deletedBlocks = blockRepository.findByDeletedBlocks(dashboardId);
+
+        blockRepository.deleteAll(deletedBlocks);
     }
 
     private Progress parseProgress(String progressString) {
@@ -197,4 +241,28 @@ public class BlockService {
             throw new InvalidProgressException();
         }
     }
+
+    private void validateDashboardAccess(Dashboard dashboard, Member member) {
+        if (dashboard instanceof PersonalDashboard) {
+            validatePersonalDashboardAccess((PersonalDashboard) dashboard, member);
+        } else {
+            validateTeamDashboardAccess((TeamDashboard) dashboard, member);
+        }
+    }
+
+    private void validatePersonalDashboardAccess(PersonalDashboard dashboard, Member member) {
+        if (!dashboard.getMember().getEmail().equals(member.getEmail())) {
+            throw new UnauthorizedAccessException();
+        }
+    }
+
+    private void validateTeamDashboardAccess(TeamDashboard dashboard, Member member) {
+        boolean isMemberInDashboard = dashboard.getTeamDashboardMemberMappings().stream()
+                .anyMatch(mapping -> mapping.getMember().equals(member));
+
+        if (!dashboard.getMember().equals(member) && !isMemberInDashboard) {
+            throw new UnauthorizedAccessException();
+        }
+    }
+
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockService.java
@@ -192,7 +192,6 @@ public class BlockService {
     }
 
     // 삭제된 블록 조회
-    @Transactional
     public BlockListResDto findDeletedBlocks(String email, Long dashboardId, Pageable pageable) {
         Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         Dashboard dashboard = dashboardRepository.findById(dashboardId).orElseThrow(DashboardNotFoundException::new);

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/util/BlockCleanupScheduler.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/application/util/BlockCleanupScheduler.java
@@ -1,0 +1,26 @@
+package shop.kkeujeok.kkeujeokbackend.block.application.util;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
+import shop.kkeujeok.kkeujeokbackend.block.domain.repository.BlockRepository;
+
+@Component
+@RequiredArgsConstructor
+public class BlockCleanupScheduler {
+
+    private final BlockRepository blockRepository;
+
+    @Scheduled(cron = "0 0 2 * * ?")
+    @Transactional
+    public void deleteOldDeletedBlocks() {
+        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+        List<Block> blocksToDeletePermanently = blockRepository.findBlocksToDeletePermanently(thirtyDaysAgo);
+        blockRepository.deleteAll(blocksToDeletePermanently);
+    }
+
+}

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockCustomRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockCustomRepository.java
@@ -1,5 +1,7 @@
 package shop.kkeujeok.kkeujeokbackend.block.domain.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import shop.kkeujeok.kkeujeokbackend.block.domain.Block;
@@ -12,4 +14,8 @@ public interface BlockCustomRepository {
     int findLastSequenceByProgress(Member member, Long dashboardId, Progress progress);
 
     Page<Block> findByDeletedBlocks(Long dashboardId, Pageable pageable);
+
+    List<Block> findByDeletedBlocks(Long dashboardId);
+
+    List<Block> findBlocksToDeletePermanently(LocalDateTime thirtyDaysAgo);
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockCustomRepositoryImpl.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/block/domain/repository/BlockCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package shop.kkeujeok.kkeujeokbackend.block.domain.repository;
 import static shop.kkeujeok.kkeujeokbackend.block.domain.QBlock.block;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -84,4 +85,23 @@ public class BlockCustomRepositoryImpl implements BlockCustomRepository {
 
         return new PageImpl<>(blocks, pageable, total);
     }
+
+    @Override
+    public List<Block> findByDeletedBlocks(Long dashboardId) {
+        return queryFactory
+                .selectFrom(block)
+                .where(block.dashboard.id.eq(dashboardId)
+                        .and(block.status.eq(Status.DELETED)))
+                .orderBy(block.sequence.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<Block> findBlocksToDeletePermanently(LocalDateTime thirtyDaysAgo) {
+        return queryFactory.selectFrom(block)
+                .where(block.status.eq(Status.DELETED)
+                        .and(block.updatedAt.before(thirtyDaysAgo)))
+                .fetch();
+    }
+
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/personal/application/PersonalDashboardService.java
@@ -7,9 +7,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import shop.kkeujeok.kkeujeokbackend.dashboard.exception.DashboardDeletedException;
 import shop.kkeujeok.kkeujeokbackend.challenge.domain.ChallengeMemberMapping;
 import shop.kkeujeok.kkeujeokbackend.challenge.domain.repository.challengeMemberMapping.ChallengeMemberMappingRepository;
+import shop.kkeujeok.kkeujeokbackend.dashboard.exception.DashboardDeletedException;
 import shop.kkeujeok.kkeujeokbackend.dashboard.exception.DashboardNotFoundException;
 import shop.kkeujeok.kkeujeokbackend.dashboard.exception.UnauthorizedAccessException;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.api.dto.request.PersonalDashboardSaveReqDto;
@@ -22,7 +22,6 @@ import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.PersonalDashboard
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.domain.repository.PersonalDashboardRepository;
 import shop.kkeujeok.kkeujeokbackend.dashboard.personal.exception.DashboardAccessDeniedException;
 import shop.kkeujeok.kkeujeokbackend.global.dto.PageInfoResDto;
-import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
 import shop.kkeujeok.kkeujeokbackend.member.exception.MemberNotFoundException;
@@ -85,7 +84,7 @@ public class PersonalDashboardService {
                 .orElseThrow(DashboardNotFoundException::new);
 
         checkIfDashboardIsDeleted(dashboard);
-        validateDashboardAccess(dashboard, member);
+        validateDashboardVisibility(dashboard, member);
 
         double blockProgress = personalDashboardRepository.calculateCompletionPercentage(dashboard.getId());
 
@@ -95,6 +94,12 @@ public class PersonalDashboardService {
     private void checkIfDashboardIsDeleted(PersonalDashboard dashboard) {
         if (dashboard.isDeleted()) {
             throw new DashboardDeletedException();
+        }
+    }
+
+    private void validateDashboardVisibility(PersonalDashboard dashboard, Member member) {
+        if (!dashboard.isPublic()) {
+            validateDashboardAccess(dashboard, member);
         }
     }
 

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/block/api/BlockControllerTest.java
@@ -497,4 +497,25 @@ class BlockControllerTest extends ControllerTest {
                 .andExpect(status().isOk());
     }
 
+    @DisplayName("DELETED 논리 삭제된 블록을 전체 삭제합니다.")
+    @Test
+    void 삭제_블록_전체_삭제() throws Exception {
+        // given
+        doNothing().when(blockService).deleteAllPermanently(anyString(), any());
+
+        // when & then
+        mockMvc.perform(delete(String.format("/api/blocks/permanent?dashboardId=%d", 1L))
+                        .header("Authorization", "Bearer token")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("block/deleteAllPermanentBlock",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("dashboardId").description("대시보드 ID")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
 }

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockServiceTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/block/application/BlockServiceTest.java
@@ -38,7 +38,6 @@ import shop.kkeujeok.kkeujeokbackend.global.entity.Status;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.domain.SocialType;
 import shop.kkeujeok.kkeujeokbackend.member.domain.repository.MemberRepository;
-import shop.kkeujeok.kkeujeokbackend.notification.application.NotificationService;
 
 @ExtendWith(MockitoExtension.class)
 class BlockServiceTest {
@@ -51,9 +50,6 @@ class BlockServiceTest {
 
     @Mock
     private DashboardRepository dashboardRepository;
-
-    @Mock
-    private NotificationService notificationService;
 
     @Mock
     private RedisTemplate<String, String> redisTemplate;
@@ -151,6 +147,7 @@ class BlockServiceTest {
         // given
         Long blockId = 1L;
         when(blockRepository.findById(blockId)).thenReturn(Optional.of(block));
+        when(dashboardRepository.findById(block.getDashboard().getId())).thenReturn(Optional.of(dashboard));
 
         // when
         BlockInfoResDto result = blockService.update("email", blockId, blockUpdateReqDto);
@@ -171,6 +168,7 @@ class BlockServiceTest {
         BlockUpdateReqDto originBlockUpdateReqDto = new BlockUpdateReqDto("Title", "Contents", "2024.07.03 13:23",
                 "2024.07.25 13:23");
         when(blockRepository.findById(blockId)).thenReturn(Optional.of(block));
+        when(dashboardRepository.findById(block.getDashboard().getId())).thenReturn(Optional.of(dashboard));
 
         // when
         BlockInfoResDto result = blockService.update("email", blockId, originBlockUpdateReqDto);
@@ -189,6 +187,7 @@ class BlockServiceTest {
         // given
         Long blockId = 1L;
         when(blockRepository.findById(blockId)).thenReturn(Optional.of(block));
+        when(dashboardRepository.findById(block.getDashboard().getId())).thenReturn(Optional.of(dashboard));
 
         // when
         BlockInfoResDto result = blockService.progressUpdate("email", blockId, "IN_PROGRESS");
@@ -219,6 +218,7 @@ class BlockServiceTest {
         // given
         Long blockId = 1L;
         when(blockRepository.findById(blockId)).thenReturn(Optional.of(block));
+        when(dashboardRepository.findById(block.getDashboard().getId())).thenReturn(Optional.of(dashboard));
 
         // when
         blockService.delete("email", blockId);
@@ -235,6 +235,7 @@ class BlockServiceTest {
         // given
         Long blockId = 1L;
         when(blockRepository.findById(blockId)).thenReturn(Optional.of(deleteBlock));
+        when(dashboardRepository.findById(block.getDashboard().getId())).thenReturn(Optional.of(dashboard));
 
         // when
         blockService.delete("email", blockId);
@@ -270,6 +271,7 @@ class BlockServiceTest {
     void 블록_순번_변경() {
         // given
         when(blockRepository.findById(anyLong())).thenReturn(Optional.of(block));
+        when(dashboardRepository.findById(block.getDashboard().getId())).thenReturn(Optional.of(dashboard));
 
         // when
         blockService.changeBlocksSequence("email", blockSequenceUpdateReqDto);
@@ -284,12 +286,29 @@ class BlockServiceTest {
         // given
         Long blockId = 1L;
         when(blockRepository.findById(blockId)).thenReturn(Optional.of(deleteBlock));
+        when(dashboardRepository.findById(block.getDashboard().getId())).thenReturn(Optional.of(dashboard));
 
         // when
         blockService.deletePermanently("email", blockId);
 
         // then
         verify(blockRepository, times(1)).delete(deleteBlock);
+    }
+
+    @DisplayName("삭제된 블록을 전체 삭제합니다.")
+    @Test
+    void 삭제_블록_전체_삭제() {
+        // given
+        Long dashboardId = 1L;
+        List<Block> deletedBlocks = List.of(deleteBlock);
+        when(blockRepository.findByDeletedBlocks(dashboardId)).thenReturn(deletedBlocks);
+        when(dashboardRepository.findById(dashboardId)).thenReturn(Optional.of(dashboard));
+
+        // when
+        blockService.deleteAllPermanently("email", dashboardId);
+
+        // then
+        verify(blockRepository).deleteAll(deletedBlocks);
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #197 

## 📝작업 내용

친구 기능이 추가되면서 아래의 기능을 추가하고 수정합니다.
- 개인 대시보드 상태가 private 일 때만 검증, public 이라면 친구, 모든 사람이 조회 가능하게 변경합니다.
- 본인 또는 팀의 블록이 아니면 제어 불가능합니다.
- 휴지통에 있는 블록은 30일이 지나면 영구삭제됩니다.
- 휴지통 전체 삭제 API를 추가합니다.
