### PR TITLE
Refactor(#233): 팀 대시보드 초대 조건 수정

### DIFF
--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/request/TeamDashboardSaveReqDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/request/TeamDashboardSaveReqDto.java
@@ -13,7 +13,9 @@ public record TeamDashboardSaveReqDto(
         @NotBlank(message = "필수 입력값 입니다.")
         @Size(max = 300)
         String description,
-        List<String> invitedEmails
+
+        List<String> invitedEmails,
+        List<String> invitedNicknamesAndTags
 ) {
     public TeamDashboard toEntity(Member member) {
         return TeamDashboard.builder()

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/request/TeamDashboardUpdateReqDto.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/dto/request/TeamDashboardUpdateReqDto.java
@@ -5,7 +5,7 @@ import java.util.List;
 public record TeamDashboardUpdateReqDto(
         String title,
         String description,
-        List<String> invitedEmails
-
+        List<String> invitedEmails,
+        List<String> invitedNicknamesAndTags
 ) {
 }

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/member/domain/repository/MemberRepository.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/member/domain/repository/MemberRepository.java
@@ -1,15 +1,17 @@
 package shop.kkeujeok.kkeujeokbackend.member.domain.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
-
-import java.util.Optional;
 
 public interface MemberRepository extends
         JpaRepository<Member, Long>,
         JpaSpecificationExecutor<Member>,
         MemberCustomRepository {
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByNicknameAndTag(String nickname, String tag);
+
     boolean existsByNickname(String nickname);
 }

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardControllerTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/api/TeamDashboardControllerTest.java
@@ -86,8 +86,10 @@ class TeamDashboardControllerTest extends ControllerTest {
                 .build();
 
         List<String> emails = List.of("joinEmail");
-        teamDashboardSaveReqDto = new TeamDashboardSaveReqDto("title", "description", emails);
-        teamDashboardUpdateReqDto = new TeamDashboardUpdateReqDto("updateTitle", "updateDescription", emails);
+        List<String> nicknamesAndTags = List.of("joinNickname#1234");
+        teamDashboardSaveReqDto = new TeamDashboardSaveReqDto("title", "description", emails, nicknamesAndTags);
+        teamDashboardUpdateReqDto = new TeamDashboardUpdateReqDto("updateTitle", "updateDescription", emails,
+                nicknamesAndTags);
         teamDashboard = teamDashboardSaveReqDto.toEntity(member);
 
         ReflectionTestUtils.setField(teamDashboard, "id", 1L);
@@ -128,7 +130,8 @@ class TeamDashboardControllerTest extends ControllerTest {
                         requestFields(
                                 fieldWithPath("title").description("팀 대시보드 제목"),
                                 fieldWithPath("description").description("팀 대시보드 설명"),
-                                fieldWithPath("invitedEmails").description("초대할 멤버 이메일")
+                                fieldWithPath("invitedEmails").description("초대할 멤버 이메일"),
+                                fieldWithPath("invitedNicknamesAndTags").description("초대할 멤버 닉네임과 태그")
                         ),
                         responseFields(
                                 fieldWithPath("statusCode").description("상태 코드"),
@@ -173,7 +176,8 @@ class TeamDashboardControllerTest extends ControllerTest {
                         requestFields(
                                 fieldWithPath("title").description("개인 대시보드 제목"),
                                 fieldWithPath("description").description("개인 대시보드 설명"),
-                                fieldWithPath("invitedEmails").description("초대할 멤버 이메일")
+                                fieldWithPath("invitedEmails").description("초대할 멤버 이메일"),
+                                fieldWithPath("invitedNicknamesAndTags").description("초대할 멤버 닉네임과 태그")
                         ),
                         responseFields(
                                 fieldWithPath("statusCode").description("상태 코드"),

--- a/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardServiceTest.java
+++ b/src/test/java/shop/kkeujeok/kkeujeokbackend/dashboard/team/application/TeamDashboardServiceTest.java
@@ -3,7 +3,6 @@ package shop.kkeujeok.kkeujeokbackend.dashboard.team.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
@@ -72,9 +71,11 @@ class TeamDashboardServiceTest {
 
         lenient().when(memberRepository.findByEmail(anyString())).thenReturn(Optional.ofNullable(member));
 
-        teamDashboardSaveReqDto = new TeamDashboardSaveReqDto("title", "description", List.of("joinEmail"));
-        teamDashboardUpdateReqDto = new TeamDashboardUpdateReqDto("updateTitle", "updateDescription",
-                List.of("joinEmail"));
+        List<String> emails = List.of("joinEmail");
+        List<String> nicknamesAndTags = List.of("joinNickname#1234");
+        teamDashboardSaveReqDto = new TeamDashboardSaveReqDto("title", "description", emails, nicknamesAndTags);
+        teamDashboardUpdateReqDto = new TeamDashboardUpdateReqDto("updateTitle", "updateDescription", emails,
+                nicknamesAndTags);
 
         teamDashboard = TeamDashboard.builder()
                 .title(teamDashboardSaveReqDto.title())


### PR DESCRIPTION
## #️⃣연관된 이슈

> #233 

## 📝작업 내용

> 팀 대시보드 초대시에 기존에는 email만 가능했다면, 닉네임 + 고유번호 조합도 가능하게 합니다.
