### PR TITLE
챌린지 인덱스 추가

### DIFF
--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/challenge/domain/Challenge.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/challenge/domain/Challenge.java
@@ -7,9 +7,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
@@ -29,6 +31,11 @@ import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 import shop.kkeujeok.kkeujeokbackend.member.exception.MemberNotFoundException;
 
 @Entity
+@Table(indexes = {
+        @Index(name = "idx_challenge_status_created_at", columnList = "status, created_at"),
+        @Index(name = "idx_challenge_member_id", columnList = "member_id"),
+        @Index(name = "idx_challenge_category", columnList = "category")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Challenge extends BaseEntity {

--- a/src/main/java/shop/kkeujeok/kkeujeokbackend/challenge/domain/ChallengeMemberMapping.java
+++ b/src/main/java/shop/kkeujeok/kkeujeokbackend/challenge/domain/ChallengeMemberMapping.java
@@ -1,8 +1,10 @@
 package shop.kkeujeok.kkeujeokbackend.challenge.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +14,11 @@ import shop.kkeujeok.kkeujeokbackend.global.entity.BaseEntity;
 import shop.kkeujeok.kkeujeokbackend.member.domain.Member;
 
 @Entity
+@Table(indexes = {
+        @Index(name = "idx_challenge_member_mapping_member", columnList = "member_id"),
+        @Index(name = "idx_challenge_member_mapping_challenge", columnList = "challenge_id"),
+        @Index(name = "idx_challenge_member_mapping_composite", columnList = "member_id, challenge_id")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChallengeMemberMapping extends BaseEntity {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #285 

## 📝작업 내용

* 전체 챌린지 목록 조회 (findAllChallenges)

조건: WHERE status = 'ACTIVE' ORDER BY created_at DESC

변경 전: 테이블 풀 스캔으로 인해 불필요한 비용 발생

변경 후: status + created_at 복합 인덱스를 사용하도록 쿼리 구조 개선
→ 정렬 + 상태 조건 모두 인덱스로 처리되어 조회 성능 향상

* 카테고리 + 키워드 검색 (findChallengesByCategoryAndKeyword)

조건: WHERE status = 'ACTIVE' AND category = ? ORDER BY created_at

status + created_at 복합 인덱스와 category 인덱스를 함께 활용하도록 최적화
→ 필터링 및 정렬 비용 감소, 검색 응답 속도 향상

* 회원별 챌린지 매핑 조회 (findChallengesByMemberInMapping)

JOIN 시 외래 키 인덱스 활용

member_id, challenge_id 복합 인덱스를 추가하여 조인 및 검색 처리 성능 개선
→ 다량 데이터 환경에서도 안정적인 조회 성능 확보

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
